### PR TITLE
fix: stabilize live Goal identity and inline bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Report component visibility from its real viewport and clipping intersections.
 - Preserve the verified Goal identity through fallback so old progress cannot attach to a
   replacement Goal.
+- Read Goal identity only from the stable objective text, excluding dynamic status and elapsed time.
+- Follow the live native Goal left and right boundaries for fixed progress width.
 
 ## 0.2.1
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 - 📌 Long composer input keeps fixed progress at its verified native position.
 - 👀 Visibility diagnostics now match what is actually visible on screen.
 - 🧬 A replacement Goal can no longer inherit progress from the previous Goal.
+- ⏱️ Status labels and elapsed time no longer make the current Goal look like a replacement.
+- 📐 Fixed progress follows the live left and right boundaries of the native Goal.
 
 This is the latest release. See the [full changelog](CHANGELOG.md) for more details.
 

--- a/packages/codex-adapter/src/anchor-adapter.ts
+++ b/packages/codex-adapter/src/anchor-adapter.ts
@@ -104,7 +104,11 @@ function textSignals(element: HTMLElement): CodexAnchorSignal[] {
 }
 
 function readGoalButtonIdentity(goalButton: HTMLElement): string | null {
-  const objective = goalButton.children[1];
+  const content = goalButton.children[1];
+  if (!content) {
+    return null;
+  }
+  const objective = content.children.length >= 3 ? content.children[1] : content;
   if (!objective) {
     return null;
   }

--- a/packages/codex-adapter/src/page-host-version.json
+++ b/packages/codex-adapter/src/page-host-version.json
@@ -1,0 +1,3 @@
+{
+  "pageHostVersion": 59
+}

--- a/packages/codex-adapter/src/page-host.ts
+++ b/packages/codex-adapter/src/page-host.ts
@@ -17,6 +17,7 @@ import {
   createDefaultCodexNativeGoalLocatorRegistry,
   matchCurrentVisibleThread,
 } from "./anchor-adapter.js";
+import pageHostVersionManifest from "./page-host-version.json" with { type: "json" };
 import {
   GOAL_PROGRESS_ELEMENT_NAME,
   removeManagedGoalProgressHosts,
@@ -27,7 +28,7 @@ import {
 } from "./sidecar-mount.js";
 
 export const GOAL_PROGRESS_PAGE_HOST_GLOBAL = "__CODEX_GOAL_PROGRESS__";
-export const GOAL_PROGRESS_PAGE_HOST_VERSION = 58;
+export const GOAL_PROGRESS_PAGE_HOST_VERSION = pageHostVersionManifest.pageHostVersion;
 export const GOAL_PROGRESS_OBSERVER_DEBOUNCE_MS = 150;
 export const GOAL_PROGRESS_OBSERVER_RETRY_DELAYS_MS = Object.freeze([
   250, 500, 1_000, 2_000, 4_000,

--- a/packages/codex-adapter/src/sidecar-mount.ts
+++ b/packages/codex-adapter/src/sidecar-mount.ts
@@ -1115,9 +1115,17 @@ export class SidecarMountController {
     this.#layoutReadCount += 1;
     const style = view.getComputedStyle(anchor);
     const anchorRect = anchor.getBoundingClientRect();
-    const width = anchorRect.width;
-    const composerRect =
-      anchor.closest<HTMLElement>("[data-codex-composer-root]")?.getBoundingClientRect() ?? null;
+    const composer = anchor.closest<HTMLElement>("[data-codex-composer-root]");
+    const composerRect = composer?.getBoundingClientRect() ?? null;
+    const hostRect = host.getBoundingClientRect();
+    const hostCssWidth = Number.parseFloat(view.getComputedStyle(host).width);
+    const scale =
+      Number.isFinite(hostCssWidth) &&
+      hostCssWidth > 0 &&
+      Number.isFinite(hostRect.width) &&
+      hostRect.width > 0
+        ? hostRect.width / hostCssWidth
+        : 1;
     const controlArea = this.#controlArea;
     const controlRect = controlArea?.getBoundingClientRect() ?? null;
     this.#nativeGeometryFingerprint = [
@@ -1125,10 +1133,52 @@ export class SidecarMountController {
       rectFingerprint(composerRect),
       rectFingerprint(controlRect),
     ].join("|");
-    const start = Number.parseFloat(style.paddingInlineStart) || 0;
-    const end = Number.parseFloat(style.paddingInlineEnd) || 0;
+    const direction = style.direction === "rtl" ? "rtl" : "ltr";
+    const composerStyle = composer ? view.getComputedStyle(composer) : null;
+    const composerContentLeft =
+      composerRect === null
+        ? null
+        : composerRect.left +
+          ((Number.parseFloat(composerStyle?.borderLeftWidth ?? "0") || 0) +
+            (Number.parseFloat(composerStyle?.paddingLeft ?? "0") || 0)) *
+            scale;
+    const composerContentRight =
+      composerRect === null
+        ? null
+        : composerRect.right -
+          ((Number.parseFloat(composerStyle?.borderRightWidth ?? "0") || 0) +
+            (Number.parseFloat(composerStyle?.paddingRight ?? "0") || 0)) *
+            scale;
+    const startBoundaryGap =
+      composerContentLeft === null || composerContentRight === null
+        ? 0
+        : direction === "rtl"
+          ? composerContentRight - anchorRect.right
+          : anchorRect.left - composerContentLeft;
+    const endBoundaryGap =
+      composerContentLeft === null || composerContentRight === null
+        ? 0
+        : direction === "rtl"
+          ? anchorRect.left - composerContentLeft
+          : composerContentRight - anchorRect.right;
+    const start =
+      Math.max(0, startBoundaryGap / scale) + (Number.parseFloat(style.paddingInlineStart) || 0);
+    const end =
+      Math.max(0, endBoundaryGap / scale) + (Number.parseFloat(style.paddingInlineEnd) || 0);
+    const availableWidth =
+      composerContentLeft === null || composerContentRight === null
+        ? anchorRect.width / scale
+        : (composerContentRight - composerContentLeft) / scale;
     const valid =
-      start >= 0 && end >= 0 && Number.isFinite(width) && width > 0 && start + end < width * 0.5;
+      Number.isFinite(scale) &&
+      scale > 0 &&
+      Number.isFinite(start) &&
+      Number.isFinite(end) &&
+      start >= 0 &&
+      end >= 0 &&
+      Number.isFinite(availableWidth) &&
+      availableWidth > 0 &&
+      start + end < availableWidth * 0.5;
     if (!valid) {
       return;
     }

--- a/scripts/build_renderer_bundle.mjs
+++ b/scripts/build_renderer_bundle.mjs
@@ -9,6 +9,13 @@ const outputDirectory = resolve(root, "dist/renderer");
 const bundlePath = resolve(outputDirectory, "goal-progress.js");
 const manifestPath = resolve(outputDirectory, "goal-progress.manifest.json");
 const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
+const pageHostVersionManifest = JSON.parse(
+  await readFile(resolve(root, "packages/codex-adapter/src/page-host-version.json"), "utf8"),
+);
+const pageHostVersion = pageHostVersionManifest.pageHostVersion;
+if (!Number.isSafeInteger(pageHostVersion) || pageHostVersion < 1) {
+  throw new Error("GOAL_PROGRESS_PAGE_HOST_VERSION_INVALID");
+}
 
 await rm(outputDirectory, { recursive: true, force: true });
 await mkdir(outputDirectory, { recursive: true });
@@ -28,7 +35,7 @@ const bundle = await readFile(bundlePath);
 const manifest = {
   schemaVersion: 1,
   releaseVersion: packageJson.version,
-  pageHostVersion: 58,
+  pageHostVersion,
   file: "goal-progress.js",
   bytes: bundle.byteLength,
   sha256: createHash("sha256").update(bundle).digest("hex"),


### PR DESCRIPTION
## What changed

- Read native Goal identity only from stable objective text.
- Ignore dynamic status labels and elapsed time when checking Goal continuity.
- Measure fixed progress width from the live native Goal left and right boundaries.
- Recalculate bounds across layout and scale changes without fixed inset values.
- Move Page Host version 59 into one shared source used by runtime and Release builds.
- Add both fixes to the v0.2.2 README summary and changelog.

## Verification

- Public `pnpm verify` passed.
- Internal fast tests: 397 passed, 2 skipped.
- Internal full tests: 565 passed, 2 skipped.
- Internal Playwright: 109 / 109 passed.
- Real Codex timer, input, scroll, pause, and resume checks kept one mounted Host with zero removals.
- Real native Goal boundary error: 0.0078 px on each side.
- Page Host v59 replaced v58 without restarting Codex.

## Merge order

This is stacked on public PR #4. Merge #4 first, then retarget this PR to `main` and merge it. Both PRs are part of v0.2.2.