### PR TITLE
fix: keep live progress across plugin updates

### DIFF
--- a/packages/ipc/src/protocol.ts
+++ b/packages/ipc/src/protocol.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import {
   GOAL_NATIVE_OBJECTIVE_MAX_LENGTH,
-  GOAL_PROGRESS_RELEASE_VERSION,
   GoalContractInitializationSchema,
   GoalProgressCommandSchema,
   GoalProgressViewModelSchema,
@@ -11,13 +10,6 @@ import {
 
 export const GOAL_PROGRESS_IPC_PROTOCOL_VERSION = 4 as const;
 export const GOAL_PROGRESS_IPC_MAX_MESSAGE_BYTES = 1_048_576;
-export const GOAL_PROGRESS_MCP_COMPATIBLE_CLIENT_VERSIONS: readonly string[] = Object.freeze([
-  GOAL_PROGRESS_RELEASE_VERSION,
-]);
-
-export function isGoalProgressMcpClientVersionCompatible(clientVersion: string): boolean {
-  return GOAL_PROGRESS_MCP_COMPATIBLE_CLIENT_VERSIONS.includes(clientVersion);
-}
 
 export const GoalProgressActivationResumeResultSchema = z.discriminatedUnion("status", [
   z

--- a/packages/ipc/src/server.ts
+++ b/packages/ipc/src/server.ts
@@ -9,7 +9,6 @@ import {
   type GoalProgressIpcRequest,
   GoalProgressIpcRequestSchema,
   type GoalProgressIpcResponse,
-  isGoalProgressMcpClientVersionCompatible,
 } from "./protocol.js";
 
 const GOAL_PROGRESS_IPC_IDLE_TIMEOUT_MS = 10_000;
@@ -313,19 +312,6 @@ export class GoalProgressIpcServer {
                     request.requestId,
                     "HANDSHAKE_REQUIRED",
                     "IPC hello must be the first request",
-                  ),
-                );
-                return;
-              }
-              if (
-                request.params.clientKind === "mcp" &&
-                !isGoalProgressMcpClientVersionCompatible(request.params.clientVersion)
-              ) {
-                terminate(
-                  errorResponse(
-                    request.requestId,
-                    "CLIENT_RECONNECT_REQUIRED",
-                    "Goal Progress MCP client must reconnect to load the current release",
                   ),
                 );
                 return;

--- a/platform/macos/src/installer.ts
+++ b/platform/macos/src/installer.ts
@@ -891,6 +891,40 @@ export function createPluginController(options: {
   readonly codexCommand: string;
 }): PluginController {
   const command = options.codexCommand;
+  const pluginCacheRoot = resolve(
+    options.codexHomeDirectory,
+    "plugins/cache",
+    MARKETPLACE_NAME,
+    PLUGIN_NAME,
+  );
+  const removeStalePluginCaches = async (currentVersion: string): Promise<void> => {
+    let entries: string[];
+    try {
+      entries = await readdir(pluginCacheRoot);
+    } catch (error) {
+      if (isNotFound(error)) {
+        return;
+      }
+      throw error;
+    }
+    await Promise.all(
+      entries
+        .filter((entry) => entry !== currentVersion)
+        .map((entry) => rm(resolve(pluginCacheRoot, entry), { recursive: true, force: true })),
+    );
+  };
+  const removePluginCache = async (): Promise<boolean> => {
+    try {
+      await lstat(pluginCacheRoot);
+    } catch (error) {
+      if (isNotFound(error)) {
+        return false;
+      }
+      throw error;
+    }
+    await rm(pluginCacheRoot, { recursive: true, force: true });
+    return true;
+  };
   const pluginList = () =>
     listedRecords(
       runCodexJson(command, ["plugin", "list", "--json"], options.codexHomeDirectory),
@@ -980,6 +1014,12 @@ export function createPluginController(options: {
   return {
     async ensure(archivePath, marketplaceRoot, reinstall, expectedTreeManifestSha256) {
       if (!reinstall && (await verifyInstalled(undefined, expectedTreeManifestSha256))) {
+        const currentPlugin = pluginList().find(
+          (candidate) => candidate.pluginId === PLUGIN_ID && candidate.installed === true,
+        );
+        if (typeof currentPlugin?.version === "string") {
+          await removeStalePluginCaches(currentPlugin.version);
+        }
         return false;
       }
       await rm(marketplaceRoot, { recursive: true, force: true });
@@ -1064,9 +1104,7 @@ export function createPluginController(options: {
         if (!(await verifyInstalled(pluginManifest.version, expectedTreeManifestSha256))) {
           throw new Error("GOAL_PROGRESS_PLUGIN_INSTALL_VERIFY_FAILED");
         }
-        if (previousCacheRoot) {
-          await rm(previousCacheRoot, { recursive: true, force: true });
-        }
+        await removeStalePluginCaches(pluginManifest.version);
         installedCurrentVersion = true;
       } finally {
         if (!installedCurrentVersion && previousCacheRoot && retainedCacheRoot) {
@@ -1100,6 +1138,7 @@ export function createPluginController(options: {
         );
         changed = true;
       }
+      changed = (await removePluginCache()) || changed;
       return changed;
     },
     async verify(releaseVersion, expectedTreeManifestSha256) {


### PR DESCRIPTION
## What changed

- remove stale Goal Progress Plugin cache versions after successful installs and upgrades
- remove cache-only leftovers during uninstall and report that cleanup as a real change
- keep already-running MCP clients connected when the IPC protocol still matches the new Helper

## Why

A live Codex task could keep the old MCP process while an update replaced the Helper and deleted the old Plugin cache. The process stayed alive, but an exact release-version check forced `CLIENT_RECONNECT_REQUIRED` even though both releases used IPC protocol v4.

The IPC protocol version is now the compatibility boundary. A real protocol change still fails through `PROTOCOL_VERSION_MISMATCH`.

## Verified

- public `pnpm verify` passed
- internal fast tests: 397 passed, 2 skipped
- internal full tests: 566 passed, 2 skipped
- Playwright: 109 passed
- real current-session upgrade from historical rc.43 to 0.2.2 completed without restarting Codex
- the same old MCP process read the same Contract after the upgrade
- progress updated from 0% to 50% after the upgrade
- the 0.2.2 Page Host mounted visibly in the native Goal area
- old cache was removed; only 0.2.2 remained
- doctor and verify passed with no old-path or reconnect errors
