### PR TITLE
fix: compact status notices and finalize v0.3.5 packaging

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -21,3 +21,4 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
+      - run: node runtime/build-runtime.mjs --source . --output .cache/source-runtime-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-## 0.3.5 - 2026-09-05 (source plugin)
+## 0.3.5 - 2026-09-06
 
 - Build the Helper locally after installing the source plugin; Node.js 22.12+ and pnpm 11 are required.
 - Generate Contract IDs in the plugin instead of asking the model to invent them.
 - Restore progress after normal Codex restarts through the source startup listener.
 - Add source upgrade rollback, explicit uninstall, and marketplace scanner CI.
 
-The published v0.3.4 prebuilt installer remains unchanged.
+- Replace the large error card with a compact status line, retained progress, Retry, and Close.
+- Keep task blockers separate from plugin failures, preserving the checklist and native paused state.
+- Refresh the renderer after same-version reinstalls and keep floating status controls inside narrow windows.
+- Build source and prebuilt packages from the same renderer revision and correct the nested prebuilt marketplace entry.
 
 ## 0.3.4 - 2026-09-02
 

--- a/packages/codex-adapter/src/page-host-version.json
+++ b/packages/codex-adapter/src/page-host-version.json
@@ -1,3 +1,0 @@
-{
-  "pageHostVersion": 61
-}

--- a/packages/codex-adapter/src/page-host.ts
+++ b/packages/codex-adapter/src/page-host.ts
@@ -1,4 +1,7 @@
 import type { GoalProgressViewModel } from "../../contracts/src/goal-contract.js";
+import pageHostVersionManifest from "../../contracts/src/page-host-version.json" with {
+  type: "json",
+};
 import { GOAL_PROGRESS_RELEASE_VERSION } from "../../contracts/src/release-version.js";
 import {
   GOAL_PROGRESS_HOT_ELEMENT_NAME,
@@ -26,7 +29,6 @@ import {
   createDefaultCodexNativeGoalLocatorRegistry,
   matchCurrentVisibleThread,
 } from "./anchor-adapter.js";
-import pageHostVersionManifest from "./page-host-version.json" with { type: "json" };
 import {
   GOAL_PROGRESS_ELEMENT_NAME,
   removeManagedGoalProgressHosts,

--- a/packages/codex-adapter/src/sidecar-mount.ts
+++ b/packages/codex-adapter/src/sidecar-mount.ts
@@ -200,6 +200,10 @@ export function removeManagedGoalProgressHosts(document: Document): number {
   return managedHosts.length;
 }
 
+function requiresInlineState(viewModel: GoalProgressViewModel | null | undefined): boolean {
+  return viewModel?.trackingPhase === "preparing";
+}
+
 function preparingViewMatchesGoalIdentity(
   viewModel: GoalProgressViewModel,
   goalIdentity: string | null,
@@ -625,7 +629,7 @@ export class SidecarMountController {
       host.hidden = uiPreference.hidden;
       host.requestedPlacement = requestedPlacement;
       host.placement =
-        preserveFallback || viewModel.trackingPhase === "preparing" ? "inline" : requestedPlacement;
+        preserveFallback || requiresInlineState(viewModel) ? "inline" : requestedPlacement;
       host.floatingXRatio = requestedFloatingXRatio;
     }
     if (host.placement !== "inline" || host.collapsed) {
@@ -776,7 +780,7 @@ export class SidecarMountController {
       this.#requestedPlacement === "inline" &&
       !threadChanged &&
       (this.#displayMode === "native" || this.#fallbackInlineOriginRetained);
-    host.placement = this.#requestedPlacement;
+    host.placement = requiresInlineState(host.viewModel) ? "inline" : this.#requestedPlacement;
     host.spaceConstrained = false;
     host.floatingPanelConstrained = false;
     const retainInlineOrigin =
@@ -1196,8 +1200,9 @@ export class SidecarMountController {
         ? composer.getBoundingClientRect()
         : null;
     const surfaceHeight =
-      host.shadowRoot?.querySelector<HTMLElement>(".floating-chip")?.getBoundingClientRect()
-        .height ?? 38;
+      host.shadowRoot
+        ?.querySelector<HTMLElement>(".floating-chip, .phase-error .state")
+        ?.getBoundingClientRect().height ?? 38;
     const fallbackBottom =
       view && composerRect
         ? Math.max(
@@ -1242,8 +1247,12 @@ export class SidecarMountController {
     if (!host) {
       return;
     }
+    // Preparing state uses normal height; errors retain the user's compact floating position.
+    if (requiresInlineState(host.viewModel)) {
+      host.placement = "inline";
+    }
     if (this.#displayMode === "fallback") {
-      host.placement = this.#requestedPlacement;
+      host.placement = requiresInlineState(host.viewModel) ? "inline" : this.#requestedPlacement;
       host.spaceConstrained = false;
       if (
         this.#fallbackInlineOriginRetained &&
@@ -1527,7 +1536,8 @@ export class SidecarMountController {
     const hostScale = this.#positionFloatingHost(host, left, targetTop, width);
     this.#floatingViewportTop = targetTop;
 
-    const chip = host.shadowRoot?.querySelector<HTMLElement>(".floating-chip") ?? null;
+    const chip =
+      host.shadowRoot?.querySelector<HTMLElement>(".floating-chip, .phase-error .state") ?? null;
     const panel = host.shadowRoot?.querySelector<HTMLElement>(".floating-panel") ?? null;
     if (
       host.floatingPanelConstrained &&
@@ -1538,7 +1548,13 @@ export class SidecarMountController {
       this.#scheduleFloatingLayout();
       return;
     }
-    if (!chip || (!host.collapsed && !host.floatingPanelConstrained && !panel)) {
+    if (
+      !chip ||
+      (host.viewModel?.trackingPhase !== "error" &&
+        !host.collapsed &&
+        !host.floatingPanelConstrained &&
+        !panel)
+    ) {
       return;
     }
     const chipRect = chip?.getBoundingClientRect() ?? null;
@@ -1706,7 +1722,7 @@ export class SidecarMountController {
 
   #retryFloatingPlacement(): void {
     const host = this.#host;
-    if (!host || this.#requestedPlacement !== "floating") {
+    if (!host || this.#requestedPlacement !== "floating" || requiresInlineState(host.viewModel)) {
       return;
     }
     this.#floatingFallbackActive = false;

--- a/packages/contracts/src/goal-contract.ts
+++ b/packages/contracts/src/goal-contract.ts
@@ -820,15 +820,19 @@ export const GoalProgressViewModelSchema = z
       });
     }
     const hasProgress = viewModel.overallProgressBps !== null && viewModel.overallPercent !== null;
-    const shouldHaveProgress =
+    const tracksProgress =
       viewModel.trackingPhase === "active" ||
       viewModel.trackingPhase === "paused" ||
       viewModel.trackingPhase === "blocked" ||
       viewModel.trackingPhase === "completed";
-    if (hasProgress !== shouldHaveProgress) {
+    if (
+      (viewModel.overallProgressBps === null) !== (viewModel.overallPercent === null) ||
+      (tracksProgress && !hasProgress) ||
+      (!tracksProgress && viewModel.trackingPhase !== "error" && hasProgress)
+    ) {
       context.addIssue({
         code: "custom",
-        message: "Progress is available only for tracking phases",
+        message: "Tracking views require progress; error views may retain confirmed progress",
         path: ["overallProgressBps"],
       });
     }

--- a/packages/contracts/src/page-host-version.json
+++ b/packages/contracts/src/page-host-version.json
@@ -1,0 +1,3 @@
+{
+  "pageHostVersion": 64
+}

--- a/packages/contracts/src/renderer-events.ts
+++ b/packages/contracts/src/renderer-events.ts
@@ -1,8 +1,9 @@
+import pageHostVersionManifest from "./page-host-version.json" with { type: "json" };
 import { GOAL_PROGRESS_RELEASE_VERSION } from "./release-version.js";
 import type { GoalProgressUiIntent } from "./ui-preference.js";
 
 export const GOAL_PROGRESS_ELEMENT_NAME = "codex-goal-progress";
-export const GOAL_PROGRESS_HOT_ELEMENT_NAME = `codex-goal-progress-v${GOAL_PROGRESS_RELEASE_VERSION.replaceAll(".", "-")}`;
+export const GOAL_PROGRESS_HOT_ELEMENT_NAME = `codex-goal-progress-v${GOAL_PROGRESS_RELEASE_VERSION.replaceAll(".", "-")}-p${pageHostVersionManifest.pageHostVersion}`;
 export const GOAL_PROGRESS_SET_COLLAPSED_EVENT = "goal-progress-set-collapsed";
 export const GOAL_PROGRESS_SET_MOTION_PAUSED_EVENT = "goal-progress-set-motion-paused";
 export const GOAL_PROGRESS_SET_PLACEMENT_EVENT = "goal-progress-set-placement";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -426,8 +426,8 @@ function viewPhase(
   contract: GoalContractAny,
   calculation: GoalProgressCalculation,
 ): Exclude<GoalProgressViewModel["trackingPhase"], "detached"> {
-  if (contract.phase === "preparing" || contract.phase === "error") {
-    return contract.phase;
+  if (contract.phase === "preparing") {
+    return "preparing";
   }
   if (calculation.completionConfirmed) {
     return "completed";
@@ -437,6 +437,9 @@ function viewPhase(
   }
   if (contract.nativeGoal.status === "blocked") {
     return "blocked";
+  }
+  if (contract.phase === "error" && contract.objectives.length === 0) {
+    return "error";
   }
   return "active";
 }
@@ -971,11 +974,11 @@ export function applyGoalProgressCommand(
   }
 
   if (command.type === "set-phase") {
-    if (command.phase === "paused") {
+    if (command.phase === "paused" || command.phase === "error") {
       return failure(
         "INVALID_TRANSITION",
         contract.revision,
-        "Pause state is read from the native Goal",
+        "Pause and error states are not model-controlled Contract phases",
       );
     }
     if (!validPhaseTransition(contract.phase, command.phase)) {

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1178,20 +1178,17 @@ export class GoalProgressHelper {
     code: string,
   ): Promise<GoalProgressViewModel> {
     const threadId = this.#threadIdOf(contract);
+    const {
+      blockedReason: _blockedReason,
+      token: _token,
+      ...confirmed
+    } = projectContract(contract);
     const viewModel = GoalProgressViewModelSchema.parse({
-      schemaVersion: 2,
-      contractId: contract.contractId,
-      sessionId: threadId,
-      revision: contract.revision,
-      scopeRevision: contract.scopeRevision,
+      ...confirmed,
       trackingPhase: "error",
-      objective: contract.nativeGoal.objective,
-      overallProgressBps: null,
-      overallPercent: null,
       finalVerificationPending: false,
       objectives: [],
       optionalObjectives: [],
-      maxVisibleObjectives: 3,
       errorCode: code,
     });
     await this.#publishVerified(threadId, viewModel);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -141,7 +141,7 @@ export const GoalProgressRescopeInputSchema = z
   .passthrough()
   .meta({ required: ["contractId", "expectedRevision", "reason", "objectives"] });
 
-const GoalProgressModelPhaseSchema = GoalProgressPhaseSchema.exclude(["paused"]);
+const GoalProgressModelPhaseSchema = GoalProgressPhaseSchema.exclude(["paused", "error"]);
 
 export const GoalProgressSetPhaseInputSchema = z
   .object({
@@ -1014,7 +1014,7 @@ export function createGoalProgressMcpServer(options: GoalProgressMcpServerOption
     {
       title: "Set Goal Progress Phase",
       description:
-        "Set preparing, active, completed, or error. Do not use it to pause; native pause is read-only.",
+        "Set preparing, active, or completed. Do not report task failures as plugin errors; native pause is read-only. Use native Goal for blockers.",
       inputSchema: GoalProgressSetPhaseInputSchema,
       outputSchema: GoalProgressToolOutputSchema,
       annotations: {

--- a/packages/renderer/src/components/states.ts
+++ b/packages/renderer/src/components/states.ts
@@ -29,34 +29,32 @@ export function renderErrorView(
   onDetach: () => void,
   messages: GoalProgressMessages,
 ) {
-  const errorCode = viewModel?.errorCode ?? "VIEW_MODEL_UNAVAILABLE";
+  const summary =
+    viewModel?.overallPercent === null || viewModel?.overallPercent === undefined
+      ? messages.unavailableTitle
+      : `${viewModel.overallPercent}% · ${messages.unavailableTitle}`;
   return html`
-    <div class="state" role="alert">
-      <div>
-        <div class="state-symbol error" aria-hidden="true">!</div>
-        <div class="state-title">${messages.unavailableTitle}</div>
-        <div class="state-copy">${messages.unavailableCopy}</div>
-        <code class="error-code">${errorCode}</code>
-        <div class="state-actions">
-          <button
-            class="icon-button retry-button"
-            type="button"
-            aria-label=${messages.retryProgress}
-            title=${messages.retry}
-            @click=${onRetry}
-          >
-            ↻
-          </button>
-          <button
-            class="icon-button detach-button"
-            type="button"
-            aria-label=${messages.closeProgress}
-            title=${messages.closeProgress}
-            @click=${onDetach}
-          >
-            ×
-          </button>
-        </div>
+    <div class="state error" role="alert">
+      <span class="error-summary">${summary}</span>
+      <div class="state-actions">
+        <button
+          class="retry-button"
+          type="button"
+          aria-label=${messages.retryProgress}
+          title=${messages.retry}
+          @click=${onRetry}
+        >
+          ${messages.retry}
+        </button>
+        <button
+          class="icon-button detach-button"
+          type="button"
+          aria-label=${messages.closeProgress}
+          title=${messages.closeProgress}
+          @click=${onDetach}
+        >
+          ×
+        </button>
       </div>
     </div>
   `;

--- a/packages/renderer/src/goal-progress-element.ts
+++ b/packages/renderer/src/goal-progress-element.ts
@@ -486,7 +486,7 @@ export class GoalProgressElement extends LitElement {
     const viewModel = this.viewModel;
     const locale = resolveGoalProgressLocale(this.locale);
     if (!viewModel) {
-      return html`<section class="panel phase-error">
+      return html`<section class="panel phase-error placement-${this.placement}">
         ${renderErrorView(null, this.#requestRetry, this.#requestDetach, locale.messages)}
       </section>`;
     }
@@ -496,7 +496,7 @@ export class GoalProgressElement extends LitElement {
       </section>`;
     }
     if (viewModel.trackingPhase === "error") {
-      return html`<section class="panel phase-error">
+      return html`<section class="panel phase-error placement-${this.placement}">
         ${renderErrorView(viewModel, this.#requestRetry, this.#requestDetach, locale.messages)}
       </section>`;
     }

--- a/packages/renderer/src/locales/am.ts
+++ b/packages/renderer/src/locales/am.ts
@@ -74,7 +74,7 @@ export const amMessages: GoalProgressMessages = {
   preparingBaseline: "የሂደት መነሻ በማዘጋጀት ላይ…",
   preparingObjectives: "የመቀበያ ነጥቦችን በማዘጋጀት ላይ…",
   preparingCopy: "የአሁኑ ሞዴል Goalን እና የመቀበያ ዝርዝሩን እየፈተሸ ነው።",
-  unavailableTitle: "የGoal ሂደት ለጊዜው አይገኝም",
+  unavailableTitle: "ሂደቱ አልተዘመነም",
   unavailableCopy: "Goal መቀጠል ይችላል። ግንኙነቱ ሲመለስ ሂደቱ እንደገና ይታያል።",
   retryProgress: "ሂደቱን እንደገና ሞክር",
   retry: "እንደገና ሞክር",

--- a/packages/renderer/src/locales/ar.ts
+++ b/packages/renderer/src/locales/ar.ts
@@ -74,7 +74,7 @@ export const arMessages: GoalProgressMessages = {
   preparingBaseline: "جارٍ إنشاء خط أساس للتقدم…",
   preparingObjectives: "جارٍ إعداد نقاط القبول…",
   preparingCopy: "يتحقق النموذج الحالي من الهدف وقائمة القبول.",
-  unavailableTitle: "تقدم الهدف غير متاح",
+  unavailableTitle: "لم يُحدَّث التقدم",
   unavailableCopy: "يمكن أن يستمر Goal. سيظهر التقدم مجددًا بعد استعادة الاتصال.",
   retryProgress: "إعادة محاولة التقدم",
   retry: "إعادة المحاولة",

--- a/packages/renderer/src/locales/bg.ts
+++ b/packages/renderer/src/locales/bg.ts
@@ -74,7 +74,7 @@ export const bgMessages: GoalProgressMessages = {
   preparingBaseline: "Създаване на начална база за напредъка…",
   preparingObjectives: "Подготовка на критериите за приемане…",
   preparingCopy: "Текущият модел проверява Goal и списъка с критерии.",
-  unavailableTitle: "Напредъкът по Goal не е достъпен",
+  unavailableTitle: "Напредъкът не е актуализиран",
   unavailableCopy: "Goal може да продължи. Напредъкът ще се върне след възстановяване на връзката.",
   retryProgress: "Повтори напредъка",
   retry: "Повтори",

--- a/packages/renderer/src/locales/bn.ts
+++ b/packages/renderer/src/locales/bn.ts
@@ -74,7 +74,7 @@ export const bnMessages: GoalProgressMessages = {
   preparingBaseline: "অগ্রগতির ভিত্তি তৈরি হচ্ছে…",
   preparingObjectives: "গ্রহণযোগ্যতার ধাপ প্রস্তুত হচ্ছে…",
   preparingCopy: "বর্তমান মডেল Goal ও গ্রহণযোগ্যতার তালিকা যাচাই করছে।",
-  unavailableTitle: "Goal-এর অগ্রগতি পাওয়া যাচ্ছে না",
+  unavailableTitle: "অগ্রগতি হালনাগাদ হয়নি",
   unavailableCopy: "Goal চলতে পারে। সংযোগ ফিরলে অগ্রগতি আবার দেখা যাবে।",
   retryProgress: "অগ্রগতি আবার চেষ্টা করুন",
   retry: "আবার চেষ্টা করুন",

--- a/packages/renderer/src/locales/bs.ts
+++ b/packages/renderer/src/locales/bs.ts
@@ -74,7 +74,7 @@ export const bsMessages: GoalProgressMessages = {
   preparingBaseline: "Postavljanje početne vrijednosti napretka…",
   preparingObjectives: "Priprema tačaka prihvatanja…",
   preparingCopy: "Trenutni model provjerava Goal i listu prihvatanja.",
-  unavailableTitle: "Napredak Goal-a nije dostupan",
+  unavailableTitle: "Napredak nije ažuriran",
   unavailableCopy: "Goal može nastaviti. Napredak će se vratiti kada se veza oporavi.",
   retryProgress: "Ponovi učitavanje napretka",
   retry: "Pokušaj ponovo",

--- a/packages/renderer/src/locales/ca.ts
+++ b/packages/renderer/src/locales/ca.ts
@@ -74,7 +74,7 @@ export const caMessages: GoalProgressMessages = {
   preparingBaseline: "S'està establint la base del progrés…",
   preparingObjectives: "S'estan preparant els punts d'acceptació…",
   preparingCopy: "El model actual està comprovant el Goal i la llista d'acceptació.",
-  unavailableTitle: "El progrés del Goal no està disponible",
+  unavailableTitle: "Progrés sense actualitzar",
   unavailableCopy: "El Goal pot continuar. El progrés tornarà quan es recuperi la connexió.",
   retryProgress: "Torna a provar el progrés",
   retry: "Torna-ho a provar",

--- a/packages/renderer/src/locales/cs.ts
+++ b/packages/renderer/src/locales/cs.ts
@@ -74,7 +74,7 @@ export const csMessages: GoalProgressMessages = {
   preparingBaseline: "Nastavování výchozího stavu průběhu…",
   preparingObjectives: "Příprava bodů přijetí…",
   preparingCopy: "Aktuální model kontroluje Goal a kontrolní seznam přijetí.",
-  unavailableTitle: "Průběh Goal není dostupný",
+  unavailableTitle: "Průběh není aktualizován",
   unavailableCopy: "Goal může pokračovat. Průběh se vrátí po obnovení připojení.",
   retryProgress: "Zkusit průběh znovu",
   retry: "Zkusit znovu",

--- a/packages/renderer/src/locales/da.ts
+++ b/packages/renderer/src/locales/da.ts
@@ -74,7 +74,7 @@ export const daMessages: GoalProgressMessages = {
   preparingBaseline: "Opretter udgangspunkt for fremdrift…",
   preparingObjectives: "Forbereder godkendelsespunkter…",
   preparingCopy: "Den aktuelle model kontrollerer Goal og godkendelseslisten.",
-  unavailableTitle: "Goal-fremdrift er ikke tilgængelig",
+  unavailableTitle: "Fremskridt ikke opdateret",
   unavailableCopy:
     "Goal kan fortsætte. Fremdriften vender tilbage, når forbindelsen er genoprettet.",
   retryProgress: "Prøv fremdrift igen",

--- a/packages/renderer/src/locales/de.ts
+++ b/packages/renderer/src/locales/de.ts
@@ -74,7 +74,7 @@ export const deMessages: GoalProgressMessages = {
   preparingBaseline: "Fortschrittsbasis wird erstellt…",
   preparingObjectives: "Abnahmepunkte werden vorbereitet…",
   preparingCopy: "Das aktuelle Modell prüft das Goal und die Abnahmeliste.",
-  unavailableTitle: "Goal-Fortschritt ist nicht verfügbar",
+  unavailableTitle: "Fortschritt nicht aktualisiert",
   unavailableCopy:
     "Das Goal kann fortgesetzt werden. Der Fortschritt erscheint nach Wiederherstellung der Verbindung.",
   retryProgress: "Fortschritt erneut laden",

--- a/packages/renderer/src/locales/el.ts
+++ b/packages/renderer/src/locales/el.ts
@@ -74,7 +74,7 @@ export const elMessages: GoalProgressMessages = {
   preparingBaseline: "Δημιουργία βάσης προόδου…",
   preparingObjectives: "Προετοιμασία σημείων αποδοχής…",
   preparingCopy: "Το τρέχον μοντέλο ελέγχει το Goal και τη λίστα αποδοχής.",
-  unavailableTitle: "Η πρόοδος του Goal δεν είναι διαθέσιμη",
+  unavailableTitle: "Η πρόοδος δεν ενημερώθηκε",
   unavailableCopy:
     "Το Goal μπορεί να συνεχίσει. Η πρόοδος θα επανέλθει όταν αποκατασταθεί η σύνδεση.",
   retryProgress: "Επανάληψη προόδου",

--- a/packages/renderer/src/locales/en.ts
+++ b/packages/renderer/src/locales/en.ts
@@ -74,7 +74,7 @@ export const enMessages: GoalProgressMessages = {
   preparingBaseline: "Establishing the progress baseline…",
   preparingObjectives: "Preparing acceptance points…",
   preparingCopy: "The current model is checking the Goal and acceptance checklist.",
-  unavailableTitle: "Goal progress is unavailable",
+  unavailableTitle: "Progress not updated",
   unavailableCopy: "The Goal can continue. Progress will return when the connection recovers.",
   retryProgress: "Retry progress",
   retry: "Retry",

--- a/packages/renderer/src/locales/es-419.ts
+++ b/packages/renderer/src/locales/es-419.ts
@@ -74,7 +74,7 @@ export const es419Messages: GoalProgressMessages = {
   preparingBaseline: "Creando la base del progreso…",
   preparingObjectives: "Preparando los puntos de aceptación…",
   preparingCopy: "El modelo actual está revisando el Goal y la lista de aceptación.",
-  unavailableTitle: "El progreso del Goal no está disponible",
+  unavailableTitle: "Progreso sin actualizar",
   unavailableCopy: "El Goal puede continuar. El progreso volverá cuando se recupere la conexión.",
   retryProgress: "Volver a cargar el progreso",
   retry: "Volver a intentar",

--- a/packages/renderer/src/locales/es-es.ts
+++ b/packages/renderer/src/locales/es-es.ts
@@ -74,7 +74,7 @@ export const esESMessages: GoalProgressMessages = {
   preparingBaseline: "Estableciendo la base del progreso…",
   preparingObjectives: "Preparando los puntos de aceptación…",
   preparingCopy: "El modelo actual está comprobando el Goal y la lista de aceptación.",
-  unavailableTitle: "El progreso del Goal no está disponible",
+  unavailableTitle: "Progreso sin actualizar",
   unavailableCopy: "El Goal puede continuar. El progreso volverá cuando se recupere la conexión.",
   retryProgress: "Volver a cargar el progreso",
   retry: "Volver a intentarlo",

--- a/packages/renderer/src/locales/et.ts
+++ b/packages/renderer/src/locales/et.ts
@@ -74,7 +74,7 @@ export const etMessages: GoalProgressMessages = {
   preparingBaseline: "Edenemise lähtepunkti loomine…",
   preparingObjectives: "Vastuvõtupunktide ettevalmistamine…",
   preparingCopy: "Praegune mudel kontrollib Goal-i ja vastuvõtuloendit.",
-  unavailableTitle: "Goal-i edenemine pole saadaval",
+  unavailableTitle: "Edenemine pole uuendatud",
   unavailableCopy: "Goal võib jätkata. Edenemine taastub koos ühendusega.",
   retryProgress: "Proovi edenemist uuesti",
   retry: "Proovi uuesti",

--- a/packages/renderer/src/locales/fa.ts
+++ b/packages/renderer/src/locales/fa.ts
@@ -74,7 +74,7 @@ export const faMessages: GoalProgressMessages = {
   preparingBaseline: "در حال تعیین مبنای پیشرفت…",
   preparingObjectives: "در حال آماده‌سازی معیارهای پذیرش…",
   preparingCopy: "مدل فعلی در حال بررسی Goal و فهرست پذیرش است.",
-  unavailableTitle: "پیشرفت Goal در دسترس نیست",
+  unavailableTitle: "پیشرفت به‌روز نشده",
   unavailableCopy: "Goal می‌تواند ادامه یابد. با بازیابی اتصال، پیشرفت دوباره نمایش داده می‌شود.",
   retryProgress: "تلاش دوباره برای پیشرفت",
   retry: "تلاش دوباره",

--- a/packages/renderer/src/locales/fi.ts
+++ b/packages/renderer/src/locales/fi.ts
@@ -74,7 +74,7 @@ export const fiMessages: GoalProgressMessages = {
   preparingBaseline: "Luodaan edistymisen lähtötasoa…",
   preparingObjectives: "Valmistellaan hyväksymiskohtia…",
   preparingCopy: "Nykyinen malli tarkistaa Goalin ja hyväksymisluettelon.",
-  unavailableTitle: "Goalin edistyminen ei ole saatavilla",
+  unavailableTitle: "Edistymistä ei ole päivitetty",
   unavailableCopy: "Goal voi jatkua. Edistyminen palaa, kun yhteys palautuu.",
   retryProgress: "Yritä edistymistä uudelleen",
   retry: "Yritä uudelleen",

--- a/packages/renderer/src/locales/fr-ca.ts
+++ b/packages/renderer/src/locales/fr-ca.ts
@@ -74,7 +74,7 @@ export const frCAMessages: GoalProgressMessages = {
   preparingBaseline: "Création du point de référence…",
   preparingObjectives: "Préparation des critères d’acceptation…",
   preparingCopy: "Le modèle actuel vérifie le Goal et la liste d’acceptation.",
-  unavailableTitle: "La progression du Goal est indisponible",
+  unavailableTitle: "Progression non actualisée",
   unavailableCopy: "Le Goal peut continuer. La progression reviendra avec la connexion.",
   retryProgress: "Réessayer la progression",
   retry: "Réessayer",

--- a/packages/renderer/src/locales/fr-fr.ts
+++ b/packages/renderer/src/locales/fr-fr.ts
@@ -74,7 +74,7 @@ export const frFRMessages: GoalProgressMessages = {
   preparingBaseline: "Création du niveau de référence…",
   preparingObjectives: "Préparation des critères d’acceptation…",
   preparingCopy: "Le modèle actuel vérifie le Goal et la liste d’acceptation.",
-  unavailableTitle: "La progression du Goal est indisponible",
+  unavailableTitle: "Progression non actualisée",
   unavailableCopy: "Le Goal peut continuer. La progression reviendra avec la connexion.",
   retryProgress: "Réessayer la progression",
   retry: "Réessayer",

--- a/packages/renderer/src/locales/gu.ts
+++ b/packages/renderer/src/locales/gu.ts
@@ -74,7 +74,7 @@ export const guMessages: GoalProgressMessages = {
   preparingBaseline: "પ્રગતિનો આધાર તૈયાર થઈ રહ્યો છે…",
   preparingObjectives: "સ્વીકૃતિ મુદ્દા તૈયાર થઈ રહ્યા છે…",
   preparingCopy: "વર્તમાન મોડેલ Goal અને સ્વીકૃતિ યાદી તપાસી રહ્યું છે.",
-  unavailableTitle: "Goal પ્રગતિ ઉપલબ્ધ નથી",
+  unavailableTitle: "પ્રગતિ અપડેટ થઈ નથી",
   unavailableCopy: "Goal ચાલુ રહી શકે છે. કનેક્શન પાછું આવે ત્યારે પ્રગતિ ફરી દેખાશે.",
   retryProgress: "પ્રગતિ ફરી અજમાવો",
   retry: "ફરી અજમાવો",

--- a/packages/renderer/src/locales/hi.ts
+++ b/packages/renderer/src/locales/hi.ts
@@ -74,7 +74,7 @@ export const hiMessages: GoalProgressMessages = {
   preparingBaseline: "प्रगति का आधार तैयार हो रहा है…",
   preparingObjectives: "स्वीकृति बिंदु तैयार हो रहे हैं…",
   preparingCopy: "वर्तमान मॉडल Goal और स्वीकृति सूची की जाँच कर रहा है।",
-  unavailableTitle: "Goal की प्रगति उपलब्ध नहीं है",
+  unavailableTitle: "प्रगति अपडेट नहीं हुई",
   unavailableCopy: "Goal जारी रह सकता है। कनेक्शन लौटने पर प्रगति फिर दिखेगी।",
   retryProgress: "प्रगति फिर आज़माएँ",
   retry: "फिर आज़माएँ",

--- a/packages/renderer/src/locales/hr.ts
+++ b/packages/renderer/src/locales/hr.ts
@@ -74,7 +74,7 @@ export const hrMessages: GoalProgressMessages = {
   preparingBaseline: "Postavljanje početnog stanja napretka…",
   preparingObjectives: "Priprema točaka prihvaćanja…",
   preparingCopy: "Trenutačni model provjerava Goal i popis prihvaćanja.",
-  unavailableTitle: "Napredak Goala nije dostupan",
+  unavailableTitle: "Napredak nije ažuriran",
   unavailableCopy: "Goal se može nastaviti. Napredak će se vratiti kad se veza obnovi.",
   retryProgress: "Ponovi dohvat napretka",
   retry: "Pokušaj ponovno",

--- a/packages/renderer/src/locales/hu.ts
+++ b/packages/renderer/src/locales/hu.ts
@@ -74,7 +74,7 @@ export const huMessages: GoalProgressMessages = {
   preparingBaseline: "Előrehaladási alapérték létrehozása…",
   preparingObjectives: "Elfogadási pontok előkészítése…",
   preparingCopy: "A jelenlegi modell ellenőrzi a Goalt és az elfogadási listát.",
-  unavailableTitle: "A Goal előrehaladása nem érhető el",
+  unavailableTitle: "Az előrehaladás nem frissült",
   unavailableCopy: "A Goal folytatódhat. Az előrehaladás a kapcsolat helyreállásakor visszatér.",
   retryProgress: "Előrehaladás újrapróbálása",
   retry: "Újra",

--- a/packages/renderer/src/locales/hy.ts
+++ b/packages/renderer/src/locales/hy.ts
@@ -74,7 +74,7 @@ export const hyMessages: GoalProgressMessages = {
   preparingBaseline: "Առաջընթացի հիմքը ստեղծվում է…",
   preparingObjectives: "Ընդունման կետերը պատրաստվում են…",
   preparingCopy: "Ընթացիկ մոդելը ստուգում է Goal-ը և ընդունման ցանկը։",
-  unavailableTitle: "Goal-ի առաջընթացը հասանելի չէ",
+  unavailableTitle: "Առաջընթացը չի թարմացվել",
   unavailableCopy: "Goal-ը կարող է շարունակվել։ Կապը վերականգնվելիս առաջընթացը կվերադառնա։",
   retryProgress: "Կրկին փորձել առաջընթացը",
   retry: "Կրկին փորձել",

--- a/packages/renderer/src/locales/id.ts
+++ b/packages/renderer/src/locales/id.ts
@@ -74,7 +74,7 @@ export const idMessages: GoalProgressMessages = {
   preparingBaseline: "Menyiapkan patokan progres…",
   preparingObjectives: "Menyiapkan poin penerimaan…",
   preparingCopy: "Model saat ini sedang memeriksa Goal dan daftar penerimaan.",
-  unavailableTitle: "Progres Goal tidak tersedia",
+  unavailableTitle: "Progres belum diperbarui",
   unavailableCopy: "Goal dapat terus berjalan. Progres akan kembali saat koneksi pulih.",
   retryProgress: "Coba lagi progres",
   retry: "Coba lagi",

--- a/packages/renderer/src/locales/is.ts
+++ b/packages/renderer/src/locales/is.ts
@@ -74,7 +74,7 @@ export const isISMessages: GoalProgressMessages = {
   preparingBaseline: "Stofnar framvindugrunn…",
   preparingObjectives: "Undirbýr staðfestingaratriði…",
   preparingCopy: "Núverandi líkan yfirfer markmiðið og gátlistann.",
-  unavailableTitle: "Framvinda markmiðs er ekki tiltæk",
+  unavailableTitle: "Framvinda ekki uppfærð",
   unavailableCopy: "Goal getur haldið áfram. Framvindan birtist aftur þegar tengingin batnar.",
   retryProgress: "Reyna framvindu aftur",
   retry: "Reyna aftur",

--- a/packages/renderer/src/locales/it.ts
+++ b/packages/renderer/src/locales/it.ts
@@ -74,7 +74,7 @@ export const itMessages: GoalProgressMessages = {
   preparingBaseline: "Creazione del riferimento di avanzamento…",
   preparingObjectives: "Preparazione dei punti di accettazione…",
   preparingCopy: "Il modello attuale sta controllando il Goal e l’elenco di accettazione.",
-  unavailableTitle: "Avanzamento del Goal non disponibile",
+  unavailableTitle: "Avanzamento non aggiornato",
   unavailableCopy:
     "Il Goal può continuare. L’avanzamento tornerà quando la connessione sarà ripristinata.",
   retryProgress: "Riprova avanzamento",

--- a/packages/renderer/src/locales/ja.ts
+++ b/packages/renderer/src/locales/ja.ts
@@ -74,7 +74,7 @@ export const jaMessages: GoalProgressMessages = {
   preparingBaseline: "進捗の基準を作成中…",
   preparingObjectives: "確認項目を準備中…",
   preparingCopy: "現在のモデルが Goal と確認リストを確認しています。",
-  unavailableTitle: "Goal の進捗を表示できません",
+  unavailableTitle: "進捗は未更新です",
   unavailableCopy: "Goal は続行できます。接続が戻ると進捗も再表示されます。",
   retryProgress: "進捗を再読み込み",
   retry: "再試行",

--- a/packages/renderer/src/locales/ka.ts
+++ b/packages/renderer/src/locales/ka.ts
@@ -74,7 +74,7 @@ export const kaMessages: GoalProgressMessages = {
   preparingBaseline: "პროგრესის საწყისი დონე მზადდება…",
   preparingObjectives: "მიღების პუნქტები მზადდება…",
   preparingCopy: "მიმდინარე მოდელი ამოწმებს Goal-ს და მიღების სიას.",
-  unavailableTitle: "Goal-ის პროგრესი მიუწვდომელია",
+  unavailableTitle: "პროგრესი არ განახლებულა",
   unavailableCopy: "Goal შეიძლება გაგრძელდეს. პროგრესი დაბრუნდება კავშირის აღდგენისას.",
   retryProgress: "პროგრესის ხელახლა ცდა",
   retry: "ხელახლა ცდა",

--- a/packages/renderer/src/locales/kk.ts
+++ b/packages/renderer/src/locales/kk.ts
@@ -74,7 +74,7 @@ export const kkMessages: GoalProgressMessages = {
   preparingBaseline: "Прогресс негізі құрылуда…",
   preparingObjectives: "Қабылдау тармақтары дайындалуда…",
   preparingCopy: "Ағымдағы модель Goal мен қабылдау тізімін тексеріп жатыр.",
-  unavailableTitle: "Goal прогресі қолжетімсіз",
+  unavailableTitle: "Прогресс жаңартылмаған",
   unavailableCopy:
     "Goal жұмысын жалғастыра алады. Байланыс қалпына келгенде прогресс қайта көрсетіледі.",
   retryProgress: "Прогресті қайталау",

--- a/packages/renderer/src/locales/kn.ts
+++ b/packages/renderer/src/locales/kn.ts
@@ -74,7 +74,7 @@ export const knMessages: GoalProgressMessages = {
   preparingBaseline: "ಪ್ರಗತಿಯ ಮೂಲ ಸ್ಥಿತಿ ಸಿದ್ಧವಾಗುತ್ತಿದೆ…",
   preparingObjectives: "ಸ್ವೀಕಾರ ಅಂಶಗಳು ಸಿದ್ಧವಾಗುತ್ತಿವೆ…",
   preparingCopy: "ಪ್ರಸ್ತುತ ಮಾದರಿ Goal ಮತ್ತು ಸ್ವೀಕಾರ ಪಟ್ಟಿಯನ್ನು ಪರಿಶೀಲಿಸುತ್ತಿದೆ.",
-  unavailableTitle: "Goal ಪ್ರಗತಿ ಲಭ್ಯವಿಲ್ಲ",
+  unavailableTitle: "ಪ್ರಗತಿ ನವೀಕರಿಸಲಾಗಿಲ್ಲ",
   unavailableCopy: "Goal ಮುಂದುವರಿಯಬಹುದು. ಸಂಪರ್ಕ ಮರಳಿದಾಗ ಪ್ರಗತಿ ಮತ್ತೆ ಕಾಣಿಸುತ್ತದೆ.",
   retryProgress: "ಪ್ರಗತಿಯನ್ನು ಮರುಪ್ರಯತ್ನಿಸಿ",
   retry: "ಮರುಪ್ರಯತ್ನಿಸಿ",

--- a/packages/renderer/src/locales/ko.ts
+++ b/packages/renderer/src/locales/ko.ts
@@ -74,7 +74,7 @@ export const koMessages: GoalProgressMessages = {
   preparingBaseline: "진행 기준 설정 중…",
   preparingObjectives: "확인 항목 준비 중…",
   preparingCopy: "현재 모델이 Goal과 확인 목록을 검토하고 있습니다.",
-  unavailableTitle: "Goal 진행률을 사용할 수 없습니다",
+  unavailableTitle: "진행률이 갱신되지 않음",
   unavailableCopy: "Goal은 계속 진행할 수 있습니다. 연결이 복구되면 진행률이 다시 표시됩니다.",
   retryProgress: "진행률 다시 시도",
   retry: "다시 시도",

--- a/packages/renderer/src/locales/lt.ts
+++ b/packages/renderer/src/locales/lt.ts
@@ -74,7 +74,7 @@ export const ltMessages: GoalProgressMessages = {
   preparingBaseline: "Kuriamas eigos atskaitos taškas…",
   preparingObjectives: "Ruošiami priėmimo punktai…",
   preparingCopy: "Dabartinis modelis tikrina Goal ir priėmimo sąrašą.",
-  unavailableTitle: "Goal eiga nepasiekiama",
+  unavailableTitle: "Eiga neatnaujinta",
   unavailableCopy: "Goal gali būti tęsiamas. Atkūrus ryšį eiga vėl bus rodoma.",
   retryProgress: "Bandyti eigą dar kartą",
   retry: "Bandyti dar kartą",

--- a/packages/renderer/src/locales/lv.ts
+++ b/packages/renderer/src/locales/lv.ts
@@ -74,7 +74,7 @@ export const lvMessages: GoalProgressMessages = {
   preparingBaseline: "Veido progresa atskaites punktu…",
   preparingObjectives: "Gatavo pieņemšanas punktus…",
   preparingCopy: "Pašreizējais modelis pārbauda Goal un pieņemšanas sarakstu.",
-  unavailableTitle: "Goal progress nav pieejams",
+  unavailableTitle: "Progress nav atjaunināts",
   unavailableCopy:
     "Goal var turpināt darbu. Kad savienojums atjaunosies, progress atkal būs redzams.",
   retryProgress: "Mēģināt progresu vēlreiz",

--- a/packages/renderer/src/locales/mk.ts
+++ b/packages/renderer/src/locales/mk.ts
@@ -74,7 +74,7 @@ export const mkMessages: GoalProgressMessages = {
   preparingBaseline: "Се поставува почетната состојба на напредокот…",
   preparingObjectives: "Се подготвуваат точки за прифаќање…",
   preparingCopy: "Тековниот модел ги проверува Goal и списокот за прифаќање.",
-  unavailableTitle: "Напредокот на Goal не е достапен",
+  unavailableTitle: "Напредокот не е ажуриран",
   unavailableCopy: "Goal може да продолжи. Напредокот ќе се врати кога ќе се обнови врската.",
   retryProgress: "Обиди се повторно за напредокот",
   retry: "Обиди се повторно",

--- a/packages/renderer/src/locales/ml.ts
+++ b/packages/renderer/src/locales/ml.ts
@@ -74,7 +74,7 @@ export const mlMessages: GoalProgressMessages = {
   preparingBaseline: "പുരോഗതി അടിസ്ഥാനരേഖ തയ്യാറാക്കുന്നു…",
   preparingObjectives: "അംഗീകാര ഇനങ്ങൾ തയ്യാറാക്കുന്നു…",
   preparingCopy: "നിലവിലെ മോഡൽ Goal-ഉം അംഗീകാര പട്ടികയും പരിശോധിക്കുന്നു.",
-  unavailableTitle: "Goal പുരോഗതി ലഭ്യമല്ല",
+  unavailableTitle: "പുരോഗതി പുതുക്കിയിട്ടില്ല",
   unavailableCopy: "Goal തുടരാം. കണക്ഷൻ വീണ്ടെടുക്കുമ്പോൾ പുരോഗതി വീണ്ടും കാണിക്കും.",
   retryProgress: "പുരോഗതി വീണ്ടും ശ്രമിക്കുക",
   retry: "വീണ്ടും ശ്രമിക്കുക",

--- a/packages/renderer/src/locales/mn.ts
+++ b/packages/renderer/src/locales/mn.ts
@@ -74,7 +74,7 @@ export const mnMessages: GoalProgressMessages = {
   preparingBaseline: "Явцын суурь түвшинг тогтоож байна…",
   preparingObjectives: "Хүлээн авах зүйлсийг бэлдэж байна…",
   preparingCopy: "Одоогийн загвар Goal болон хүлээн авах жагсаалтыг шалгаж байна.",
-  unavailableTitle: "Goal явц боломжгүй",
+  unavailableTitle: "Явц шинэчлэгдээгүй",
   unavailableCopy: "Goal үргэлжлүүлэн ажиллаж болно. Холболт сэргэхэд явц дахин харагдана.",
   retryProgress: "Явцыг дахин оролдох",
   retry: "Дахин оролдох",

--- a/packages/renderer/src/locales/mr.ts
+++ b/packages/renderer/src/locales/mr.ts
@@ -74,7 +74,7 @@ export const mrMessages: GoalProgressMessages = {
   preparingBaseline: "प्रगतीचा आधार तयार करत आहे…",
   preparingObjectives: "स्वीकृती मुद्दे तयार करत आहे…",
   preparingCopy: "सध्याचे मॉडेल Goal आणि स्वीकृती सूची तपासत आहे.",
-  unavailableTitle: "Goal प्रगती उपलब्ध नाही",
+  unavailableTitle: "प्रगती अपडेट झालेली नाही",
   unavailableCopy: "Goal सुरू राहू शकते. कनेक्शन पूर्ववत झाल्यावर प्रगती पुन्हा दिसेल.",
   retryProgress: "प्रगतीसाठी पुन्हा प्रयत्न करा",
   retry: "पुन्हा प्रयत्न करा",

--- a/packages/renderer/src/locales/ms.ts
+++ b/packages/renderer/src/locales/ms.ts
@@ -74,7 +74,7 @@ export const msMessages: GoalProgressMessages = {
   preparingBaseline: "Menetapkan garis dasar kemajuan…",
   preparingObjectives: "Menyediakan perkara penerimaan…",
   preparingCopy: "Model semasa sedang menyemak Goal dan senarai penerimaan.",
-  unavailableTitle: "Kemajuan Goal tidak tersedia",
+  unavailableTitle: "Kemajuan belum dikemas kini",
   unavailableCopy: "Goal boleh diteruskan. Kemajuan akan muncul semula apabila sambungan pulih.",
   retryProgress: "Cuba semula kemajuan",
   retry: "Cuba lagi",

--- a/packages/renderer/src/locales/my.ts
+++ b/packages/renderer/src/locales/my.ts
@@ -74,7 +74,7 @@ export const myMessages: GoalProgressMessages = {
   preparingBaseline: "တိုးတက်မှု အခြေခံအမှတ် သတ်မှတ်နေသည်…",
   preparingObjectives: "လက်ခံချက်များ ပြင်ဆင်နေသည်…",
   preparingCopy: "လက်ရှိမော်ဒယ်သည် Goal နှင့် လက်ခံချက်စာရင်းကို စစ်ဆေးနေသည်။",
-  unavailableTitle: "Goal တိုးတက်မှု မရရှိနိုင်ပါ",
+  unavailableTitle: "တိုးတက်မှုကို မွမ်းမံမထားသေးပါ",
   unavailableCopy: "Goal ကို ဆက်လုပ်နိုင်သည်။ ချိတ်ဆက်မှု ပြန်ရသောအခါ တိုးတက်မှုကို ပြန်ပြမည်။",
   retryProgress: "တိုးတက်မှုကို ပြန်စမ်းရန်",
   retry: "ပြန်စမ်းရန်",

--- a/packages/renderer/src/locales/nb.ts
+++ b/packages/renderer/src/locales/nb.ts
@@ -74,7 +74,7 @@ export const nbMessages: GoalProgressMessages = {
   preparingBaseline: "Oppretter utgangspunkt for fremdrift…",
   preparingObjectives: "Forbereder godkjenningspunkter…",
   preparingCopy: "Gjeldende modell kontrollerer Goal og godkjenningslisten.",
-  unavailableTitle: "Goal-fremdrift er utilgjengelig",
+  unavailableTitle: "Fremdriften er ikke oppdatert",
   unavailableCopy: "Goal kan fortsette. Fremdriften vises igjen når tilkoblingen er gjenopprettet.",
   retryProgress: "Prøv fremdrift på nytt",
   retry: "Prøv igjen",

--- a/packages/renderer/src/locales/nl.ts
+++ b/packages/renderer/src/locales/nl.ts
@@ -74,7 +74,7 @@ export const nlMessages: GoalProgressMessages = {
   preparingBaseline: "Uitgangspunt voor voortgang bepalen…",
   preparingObjectives: "Acceptatiepunten voorbereiden…",
   preparingCopy: "Het huidige model controleert de Goal en acceptatielijst.",
-  unavailableTitle: "Goal-voortgang is niet beschikbaar",
+  unavailableTitle: "Voortgang niet bijgewerkt",
   unavailableCopy:
     "De Goal kan doorgaan. De voortgang verschijnt weer zodra de verbinding is hersteld.",
   retryProgress: "Voortgang opnieuw proberen",

--- a/packages/renderer/src/locales/pa.ts
+++ b/packages/renderer/src/locales/pa.ts
@@ -74,7 +74,7 @@ export const paMessages: GoalProgressMessages = {
   preparingBaseline: "ਪ੍ਰਗਤੀ ਦਾ ਆਧਾਰ ਤਿਆਰ ਹੋ ਰਿਹਾ ਹੈ…",
   preparingObjectives: "ਸਵੀਕ੍ਰਿਤੀ ਬਿੰਦੂ ਤਿਆਰ ਹੋ ਰਹੇ ਹਨ…",
   preparingCopy: "ਮੌਜੂਦਾ ਮਾਡਲ Goal ਅਤੇ ਸਵੀਕ੍ਰਿਤੀ ਸੂਚੀ ਦੀ ਜਾਂਚ ਕਰ ਰਿਹਾ ਹੈ।",
-  unavailableTitle: "Goal ਪ੍ਰਗਤੀ ਉਪਲਬਧ ਨਹੀਂ",
+  unavailableTitle: "ਤਰੱਕੀ ਅੱਪਡੇਟ ਨਹੀਂ ਹੋਈ",
   unavailableCopy: "Goal ਜਾਰੀ ਰਹਿ ਸਕਦਾ ਹੈ। ਕਨੈਕਸ਼ਨ ਠੀਕ ਹੋਣ 'ਤੇ ਪ੍ਰਗਤੀ ਮੁੜ ਦਿਖੇਗੀ।",
   retryProgress: "ਪ੍ਰਗਤੀ ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰੋ",
   retry: "ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰੋ",

--- a/packages/renderer/src/locales/pl.ts
+++ b/packages/renderer/src/locales/pl.ts
@@ -74,7 +74,7 @@ export const plMessages: GoalProgressMessages = {
   preparingBaseline: "Ustalanie punktu odniesienia postępu…",
   preparingObjectives: "Przygotowywanie punktów odbioru…",
   preparingCopy: "Bieżący model sprawdza Goal i listę odbioru.",
-  unavailableTitle: "Postęp Goal jest niedostępny",
+  unavailableTitle: "Postęp nie został zaktualizowany",
   unavailableCopy: "Goal może działać dalej. Postęp wróci po odzyskaniu połączenia.",
   retryProgress: "Ponów wczytywanie postępu",
   retry: "Ponów",

--- a/packages/renderer/src/locales/pt-br.ts
+++ b/packages/renderer/src/locales/pt-br.ts
@@ -74,7 +74,7 @@ export const ptBRMessages: GoalProgressMessages = {
   preparingBaseline: "Criando a base do progresso…",
   preparingObjectives: "Preparando pontos de aceitação…",
   preparingCopy: "O modelo atual está verificando o Goal e a lista de aceitação.",
-  unavailableTitle: "O progresso do Goal está indisponível",
+  unavailableTitle: "Progresso não atualizado",
   unavailableCopy: "O Goal pode continuar. O progresso voltará quando a conexão for restabelecida.",
   retryProgress: "Tentar carregar o progresso novamente",
   retry: "Tentar novamente",

--- a/packages/renderer/src/locales/pt-pt.ts
+++ b/packages/renderer/src/locales/pt-pt.ts
@@ -74,7 +74,7 @@ export const ptPTMessages: GoalProgressMessages = {
   preparingBaseline: "A criar a referência de progresso…",
   preparingObjectives: "A preparar pontos de aceitação…",
   preparingCopy: "O modelo atual está a verificar o Goal e a lista de aceitação.",
-  unavailableTitle: "O progresso do Goal está indisponível",
+  unavailableTitle: "Progresso não atualizado",
   unavailableCopy: "O Goal pode continuar. O progresso voltará quando a ligação for restabelecida.",
   retryProgress: "Tentar carregar o progresso novamente",
   retry: "Tentar novamente",

--- a/packages/renderer/src/locales/ro.ts
+++ b/packages/renderer/src/locales/ro.ts
@@ -74,7 +74,7 @@ export const roMessages: GoalProgressMessages = {
   preparingBaseline: "Se stabilește baza progresului…",
   preparingObjectives: "Se pregătesc punctele de acceptare…",
   preparingCopy: "Modelul curent verifică Goal-ul și lista de acceptare.",
-  unavailableTitle: "Progresul Goal nu este disponibil",
+  unavailableTitle: "Progres neactualizat",
   unavailableCopy: "Goal-ul poate continua. Progresul va reveni când se restabilește conexiunea.",
   retryProgress: "Reîncearcă încărcarea progresului",
   retry: "Reîncearcă",

--- a/packages/renderer/src/locales/ru.ts
+++ b/packages/renderer/src/locales/ru.ts
@@ -74,7 +74,7 @@ export const ruMessages: GoalProgressMessages = {
   preparingBaseline: "Подготовка исходного прогресса…",
   preparingObjectives: "Подготовка критериев приёмки…",
   preparingCopy: "Текущая модель проверяет Goal и список приёмки.",
-  unavailableTitle: "Прогресс Goal недоступен",
+  unavailableTitle: "Прогресс не обновлён",
   unavailableCopy:
     "Goal может продолжать работу. Прогресс вернётся после восстановления подключения.",
   retryProgress: "Повторить загрузку прогресса",

--- a/packages/renderer/src/locales/sk.ts
+++ b/packages/renderer/src/locales/sk.ts
@@ -74,7 +74,7 @@ export const skMessages: GoalProgressMessages = {
   preparingBaseline: "Vytvára sa základ priebehu…",
   preparingObjectives: "Pripravujú sa body prijatia…",
   preparingCopy: "Aktuálny model kontroluje Goal a kontrolný zoznam prijatia.",
-  unavailableTitle: "Priebeh Goal nie je dostupný",
+  unavailableTitle: "Priebeh nie je aktualizovaný",
   unavailableCopy: "Goal môže pokračovať. Priebeh sa vráti po obnovení pripojenia.",
   retryProgress: "Znova načítať priebeh",
   retry: "Skúsiť znova",

--- a/packages/renderer/src/locales/sl.ts
+++ b/packages/renderer/src/locales/sl.ts
@@ -74,7 +74,7 @@ export const slMessages: GoalProgressMessages = {
   preparingBaseline: "Vzpostavljanje osnove napredka…",
   preparingObjectives: "Priprava točk sprejema…",
   preparingCopy: "Trenutni model preverja Goal in kontrolni seznam sprejema.",
-  unavailableTitle: "Napredek Goal ni na voljo",
+  unavailableTitle: "Napredek ni posodobljen",
   unavailableCopy: "Goal se lahko nadaljuje. Napredek se vrne, ko se povezava obnovi.",
   retryProgress: "Znova naloži napredek",
   retry: "Poskusi znova",

--- a/packages/renderer/src/locales/so.ts
+++ b/packages/renderer/src/locales/so.ts
@@ -74,7 +74,7 @@ export const soMessages: GoalProgressMessages = {
   preparingBaseline: "Saldhigga horumarka ayaa la diyaarinayaa…",
   preparingObjectives: "Qodobbada aqbalaadda ayaa la diyaarinayaa…",
   preparingCopy: "Moodalka hadda wuxuu hubinayaa Goal iyo liiska aqbalaadda.",
-  unavailableTitle: "Horumarka Goal lama heli karo",
+  unavailableTitle: "Horumarka lama cusboonaysiin",
   unavailableCopy: "Goal wuu sii socon karaa. Horumarku wuu soo noqonayaa marka xiriirku hagaago.",
   retryProgress: "Mar kale soo rar horumarka",
   retry: "Mar kale isku day",

--- a/packages/renderer/src/locales/sq.ts
+++ b/packages/renderer/src/locales/sq.ts
@@ -74,7 +74,7 @@ export const sqMessages: GoalProgressMessages = {
   preparingBaseline: "Duke krijuar bazën e përparimit…",
   preparingObjectives: "Duke përgatitur pikat e pranimit…",
   preparingCopy: "Modeli aktual po kontrollon Goal-in dhe listën e pranimit.",
-  unavailableTitle: "Përparimi i Goal-it nuk është i disponueshëm",
+  unavailableTitle: "Përparimi nuk është përditësuar",
   unavailableCopy: "Goal-i mund të vazhdojë. Përparimi do të rikthehet kur të rregullohet lidhja.",
   retryProgress: "Riprovo ngarkimin e përparimit",
   retry: "Riprovo",

--- a/packages/renderer/src/locales/sr.ts
+++ b/packages/renderer/src/locales/sr.ts
@@ -74,7 +74,7 @@ export const srMessages: GoalProgressMessages = {
   preparingBaseline: "Постављање основе напретка…",
   preparingObjectives: "Припрема тачака прихватања…",
   preparingCopy: "Тренутни модел проверава Goal и листу прихватања.",
-  unavailableTitle: "Напредак Goal није доступан",
+  unavailableTitle: "Напредак није ажуриран",
   unavailableCopy: "Goal може да настави. Напредак ће се вратити када се веза обнови.",
   retryProgress: "Поново учитај напредак",
   retry: "Покушај поново",

--- a/packages/renderer/src/locales/sv.ts
+++ b/packages/renderer/src/locales/sv.ts
@@ -74,7 +74,7 @@ export const svMessages: GoalProgressMessages = {
   preparingBaseline: "Skapar utgångspunkt för förloppet…",
   preparingObjectives: "Förbereder godkännandepunkter…",
   preparingCopy: "Den aktuella modellen kontrollerar Goal och godkännandelistan.",
-  unavailableTitle: "Goal-förloppet är inte tillgängligt",
+  unavailableTitle: "Förloppet har inte uppdaterats",
   unavailableCopy: "Goal kan fortsätta. Förloppet visas igen när anslutningen återställs.",
   retryProgress: "Försök läsa in förloppet igen",
   retry: "Försök igen",

--- a/packages/renderer/src/locales/sw.ts
+++ b/packages/renderer/src/locales/sw.ts
@@ -74,7 +74,7 @@ export const swMessages: GoalProgressMessages = {
   preparingBaseline: "Inaweka msingi wa maendeleo…",
   preparingObjectives: "Inaandaa vipengee vya kukubali…",
   preparingCopy: "Muundo wa sasa unaangalia Goal na orodha ya kukubali.",
-  unavailableTitle: "Maendeleo ya Goal hayapatikani",
+  unavailableTitle: "Maendeleo hayajasasishwa",
   unavailableCopy: "Goal inaweza kuendelea. Maendeleo yatarudi muunganisho ukirejea.",
   retryProgress: "Jaribu kupakia maendeleo tena",
   retry: "Jaribu tena",

--- a/packages/renderer/src/locales/ta.ts
+++ b/packages/renderer/src/locales/ta.ts
@@ -74,7 +74,7 @@ export const taMessages: GoalProgressMessages = {
   preparingBaseline: "முன்னேற்ற அடிப்படையை அமைக்கிறது…",
   preparingObjectives: "ஏற்புப் புள்ளிகளைத் தயாரிக்கிறது…",
   preparingCopy: "தற்போதைய மாதிரி Goal மற்றும் ஏற்புப் பட்டியலைச் சரிபார்க்கிறது.",
-  unavailableTitle: "Goal முன்னேற்றம் கிடைக்கவில்லை",
+  unavailableTitle: "முன்னேற்றம் புதுப்பிக்கப்படவில்லை",
   unavailableCopy: "Goal தொடர்ந்து இயங்கலாம். இணைப்பு மீண்டதும் முன்னேற்றம் திரும்பும்.",
   retryProgress: "முன்னேற்றத்தை மீண்டும் ஏற்று",
   retry: "மீண்டும் முயல்க",

--- a/packages/renderer/src/locales/te.ts
+++ b/packages/renderer/src/locales/te.ts
@@ -74,7 +74,7 @@ export const teMessages: GoalProgressMessages = {
   preparingBaseline: "పురోగతి ఆధారాన్ని సిద్ధం చేస్తోంది…",
   preparingObjectives: "అంగీకార అంశాలను సిద్ధం చేస్తోంది…",
   preparingCopy: "ప్రస్తుత మోడల్ Goal మరియు అంగీకార జాబితాను తనిఖీ చేస్తోంది.",
-  unavailableTitle: "Goal పురోగతి అందుబాటులో లేదు",
+  unavailableTitle: "పురోగతి నవీకరించబడలేదు",
   unavailableCopy: "Goal కొనసాగవచ్చు. కనెక్షన్ తిరిగి వచ్చినప్పుడు పురోగతి కనిపిస్తుంది.",
   retryProgress: "పురోగతిని మళ్లీ లోడ్ చేయండి",
   retry: "మళ్లీ ప్రయత్నించండి",

--- a/packages/renderer/src/locales/th.ts
+++ b/packages/renderer/src/locales/th.ts
@@ -74,7 +74,7 @@ export const thMessages: GoalProgressMessages = {
   preparingBaseline: "กำลังสร้างค่าตั้งต้นของความคืบหน้า…",
   preparingObjectives: "กำลังเตรียมจุดตรวจรับ…",
   preparingCopy: "โมเดลปัจจุบันกำลังตรวจสอบ Goal และรายการตรวจรับ",
-  unavailableTitle: "ความคืบหน้าของ Goal ไม่พร้อมใช้งาน",
+  unavailableTitle: "ยังไม่อัปเดตความคืบหน้า",
   unavailableCopy: "Goal ทำงานต่อได้ ความคืบหน้าจะกลับมาเมื่อเชื่อมต่อได้อีกครั้ง",
   retryProgress: "ลองโหลดความคืบหน้าอีกครั้ง",
   retry: "ลองอีกครั้ง",

--- a/packages/renderer/src/locales/tl.ts
+++ b/packages/renderer/src/locales/tl.ts
@@ -74,7 +74,7 @@ export const tlMessages: GoalProgressMessages = {
   preparingBaseline: "Inihahanda ang batayan ng progreso…",
   preparingObjectives: "Inihahanda ang mga punto ng pagtanggap…",
   preparingCopy: "Sinusuri ng kasalukuyang modelo ang Goal at listahan ng pagtanggap.",
-  unavailableTitle: "Hindi available ang progreso ng Goal",
+  unavailableTitle: "Hindi pa na-update ang progreso",
   unavailableCopy:
     "Maaaring magpatuloy ang Goal. Babalik ang progreso kapag bumalik ang koneksyon.",
   retryProgress: "I-load muli ang progreso",

--- a/packages/renderer/src/locales/tr.ts
+++ b/packages/renderer/src/locales/tr.ts
@@ -74,7 +74,7 @@ export const trMessages: GoalProgressMessages = {
   preparingBaseline: "İlerleme temeli hazırlanıyor…",
   preparingObjectives: "Kabul noktaları hazırlanıyor…",
   preparingCopy: "Geçerli model Goal'u ve kabul listesini denetliyor.",
-  unavailableTitle: "Goal ilerlemesi kullanılamıyor",
+  unavailableTitle: "İlerleme güncellenmedi",
   unavailableCopy: "Goal çalışmaya devam edebilir. Bağlantı düzeldiğinde ilerleme geri gelir.",
   retryProgress: "İlerlemeyi yeniden yükle",
   retry: "Yeniden dene",

--- a/packages/renderer/src/locales/uk.ts
+++ b/packages/renderer/src/locales/uk.ts
@@ -74,7 +74,7 @@ export const ukMessages: GoalProgressMessages = {
   preparingBaseline: "Створення основи прогресу…",
   preparingObjectives: "Підготовка критеріїв приймання…",
   preparingCopy: "Поточна модель перевіряє Goal і список приймання.",
-  unavailableTitle: "Прогрес Goal недоступний",
+  unavailableTitle: "Прогрес не оновлено",
   unavailableCopy: "Goal може працювати далі. Прогрес повернеться після відновлення з'єднання.",
   retryProgress: "Повторити завантаження прогресу",
   retry: "Повторити",

--- a/packages/renderer/src/locales/ur.ts
+++ b/packages/renderer/src/locales/ur.ts
@@ -74,7 +74,7 @@ export const urMessages: GoalProgressMessages = {
   preparingBaseline: "پیش رفت کی بنیاد تیار ہو رہی ہے…",
   preparingObjectives: "قبولیت کے نکات تیار ہو رہے ہیں…",
   preparingCopy: "موجودہ ماڈل Goal اور قبولیت کی فہرست جانچ رہا ہے۔",
-  unavailableTitle: "Goal کی پیش رفت دستیاب نہیں",
+  unavailableTitle: "پیش رفت اپ ڈیٹ نہیں ہوئی",
   unavailableCopy: "Goal جاری رہ سکتا ہے۔ رابطہ بحال ہونے پر پیش رفت واپس آ جائے گی۔",
   retryProgress: "پیش رفت دوبارہ لوڈ کریں",
   retry: "دوبارہ کوشش کریں",

--- a/packages/renderer/src/locales/vi.ts
+++ b/packages/renderer/src/locales/vi.ts
@@ -74,7 +74,7 @@ export const viMessages: GoalProgressMessages = {
   preparingBaseline: "Đang thiết lập mốc tiến độ…",
   preparingObjectives: "Đang chuẩn bị các điểm nghiệm thu…",
   preparingCopy: "Mô hình hiện tại đang kiểm tra Goal và danh sách nghiệm thu.",
-  unavailableTitle: "Tiến độ Goal không khả dụng",
+  unavailableTitle: "Tiến độ chưa được cập nhật",
   unavailableCopy: "Goal vẫn có thể tiếp tục. Tiến độ sẽ trở lại khi kết nối được khôi phục.",
   retryProgress: "Tải lại tiến độ",
   retry: "Thử lại",

--- a/packages/renderer/src/locales/zh-cn.ts
+++ b/packages/renderer/src/locales/zh-cn.ts
@@ -74,7 +74,7 @@ export const zhCNMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立进度基线…",
   preparingObjectives: "正在准备专属验收点…",
   preparingCopy: "当前模型正在检查目标与验收清单。",
-  unavailableTitle: "目标进度暂不可用",
+  unavailableTitle: "进度暂未更新",
   unavailableCopy: "Goal 可以继续工作。连接恢复后，进度会重新显示。",
   retryProgress: "重试进度",
   retry: "重试",

--- a/packages/renderer/src/locales/zh-hk.ts
+++ b/packages/renderer/src/locales/zh-hk.ts
@@ -74,7 +74,7 @@ export const zhHKMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立進度基準…",
   preparingObjectives: "正在準備驗收項目…",
   preparingCopy: "目前的模型正在檢查 Goal 及驗收清單。",
-  unavailableTitle: "目標進度暫時無法使用",
+  unavailableTitle: "進度暫未更新",
   unavailableCopy: "Goal 可以繼續運作。連線恢復後，進度會再次顯示。",
   retryProgress: "重新載入進度",
   retry: "重試",

--- a/packages/renderer/src/locales/zh-tw.ts
+++ b/packages/renderer/src/locales/zh-tw.ts
@@ -74,7 +74,7 @@ export const zhTWMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立進度基準…",
   preparingObjectives: "正在準備驗收項目…",
   preparingCopy: "目前的模型正在檢查 Goal 與驗收清單。",
-  unavailableTitle: "目標進度目前無法使用",
+  unavailableTitle: "進度暫未更新",
   unavailableCopy: "Goal 可以繼續執行。連線恢復後，進度會再次顯示。",
   retryProgress: "重試載入進度",
   retry: "重試",

--- a/packages/renderer/src/styles/states.ts
+++ b/packages/renderer/src/styles/states.ts
@@ -10,10 +10,6 @@ export const stateStyles = css`
       text-align: center;
     }
 
-    .phase-error .state {
-      min-height: calc(var(--gp-font-size) * 10.857143);
-    }
-
     .state-symbol {
       position: relative;
       display: grid;
@@ -46,11 +42,6 @@ export const stateStyles = css`
       content: none;
     }
 
-    .state-symbol.error {
-      border-color: color-mix(in srgb, var(--gp-blocked) 56%, transparent);
-      color: var(--gp-blocked);
-    }
-
     .state-title {
       color: var(--gp-text);
       font-size: max(10px, calc(var(--gp-font-size) - 2px));
@@ -66,20 +57,67 @@ export const stateStyles = css`
       line-height: 1.5;
     }
 
-    .error-code {
-      display: inline-block;
-      margin-top: calc(var(--gp-font-size) * 0.571429);
-      color: var(--gp-blocked);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: max(9px, calc(var(--gp-font-size) - 5px));
-      overflow-wrap: anywhere;
+    .phase-error .state {
+      display: flex;
+      min-height: 36px;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 4px;
+      padding: 4px 8px 4px 12px;
+      color: var(--gp-muted);
+      font-size: var(--gp-font-size-sm);
+      line-height: 1.35;
+      text-align: start;
+    }
+
+    .error-summary {
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .state-actions {
       display: flex;
-      justify-content: center;
-      gap: calc(var(--gp-font-size) * 0.285714);
-      margin-top: calc(var(--gp-font-size) * 0.714286);
+      flex: none;
+      align-items: center;
+      gap: 2px;
+      margin-inline-start: auto;
+    }
+
+    .retry-button {
+      min-height: 24px;
+      border: 0;
+      border-radius: var(--gp-control-radius);
+      padding: 2px 6px;
+      background: transparent;
+      color: var(--gp-accent);
+      cursor: pointer;
+      font: inherit;
+    }
+
+    .retry-button:hover,
+    .retry-button:focus-visible {
+      background: var(--gp-control-hover);
+    }
+
+    .retry-button:focus-visible {
+      outline: 2px solid var(--gp-focus);
+      outline-offset: 1px;
+    }
+
+    .panel.phase-error.placement-floating .state {
+      position: absolute;
+      z-index: 1;
+      bottom: var(--gp-floating-stack-lift, 0px);
+      left: var(--gp-floating-chip-center, 50%);
+      width: min(280px, calc(100% - 20px));
+      border: 1px solid var(--gp-line);
+      border-radius: 15px;
+      background: var(--gp-panel-glass);
+      box-shadow: none;
+      pointer-events: auto;
+      transform: translateX(-50%);
     }
 
     .sr-only {

--- a/platform/macos/src/plugin-release.ts
+++ b/platform/macos/src/plugin-release.ts
@@ -38,6 +38,20 @@ function record(value: unknown, code: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+export function createReleaseMarketplaceManifest(sourceMarketplace: unknown): string {
+  const code = "GOAL_PROGRESS_RELEASE_MARKETPLACE_INVALID";
+  const marketplace = structuredClone(record(sourceMarketplace, code));
+  if (!Array.isArray(marketplace.plugins)) throw new Error(code);
+  const plugin = marketplace.plugins.find(
+    (entry: unknown) => record(entry, code).name === "codex-goal-progress",
+  );
+  if (!plugin) throw new Error(code);
+  const source = record(record(plugin, code).source, code);
+  if (source.source !== "local") throw new Error(code);
+  source.path = "./plugins/codex-goal-progress";
+  return `${JSON.stringify(marketplace, null, 2)}\n`;
+}
+
 export function createReleasePluginManifest(sourceManifest: unknown): string {
   const manifest = structuredClone(record(sourceManifest, "GOAL_PROGRESS_PLUGIN_MANIFEST_INVALID"));
   delete manifest.scripts;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,8 +559,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -715,8 +715,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -1054,7 +1054,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1066,7 +1066,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -1200,7 +1200,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -1213,7 +1213,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   finalhandler@2.1.1:
     dependencies:
@@ -1352,7 +1352,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/runtime/build-runtime.mjs
+++ b/runtime/build-runtime.mjs
@@ -25,7 +25,7 @@ if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/u.test(releaseVer
   throw new Error("GOAL_PROGRESS_SOURCE_BUILD_VERSION_INVALID");
 }
 const pageHostVersionDocument = JSON.parse(
-  await readFile(resolve(sourceRoot, "packages/codex-adapter/src/page-host-version.json"), "utf8"),
+  await readFile(resolve(sourceRoot, "packages/contracts/src/page-host-version.json"), "utf8"),
 );
 const pageHostVersion = pageHostVersionDocument.pageHostVersion;
 if (!Number.isSafeInteger(pageHostVersion) || pageHostVersion < 1) {

--- a/runtime/source/packages/codex-adapter/src/page-host-version.json
+++ b/runtime/source/packages/codex-adapter/src/page-host-version.json
@@ -1,3 +1,0 @@
-{
-  "pageHostVersion": 61
-}

--- a/runtime/source/packages/codex-adapter/src/page-host.ts
+++ b/runtime/source/packages/codex-adapter/src/page-host.ts
@@ -1,4 +1,7 @@
 import type { GoalProgressViewModel } from "../../contracts/src/goal-contract.js";
+import pageHostVersionManifest from "../../contracts/src/page-host-version.json" with {
+  type: "json",
+};
 import { GOAL_PROGRESS_RELEASE_VERSION } from "../../contracts/src/release-version.js";
 import {
   GOAL_PROGRESS_HOT_ELEMENT_NAME,
@@ -26,7 +29,6 @@ import {
   createDefaultCodexNativeGoalLocatorRegistry,
   matchCurrentVisibleThread,
 } from "./anchor-adapter.js";
-import pageHostVersionManifest from "./page-host-version.json" with { type: "json" };
 import {
   GOAL_PROGRESS_ELEMENT_NAME,
   removeManagedGoalProgressHosts,

--- a/runtime/source/packages/codex-adapter/src/sidecar-mount.ts
+++ b/runtime/source/packages/codex-adapter/src/sidecar-mount.ts
@@ -200,6 +200,10 @@ export function removeManagedGoalProgressHosts(document: Document): number {
   return managedHosts.length;
 }
 
+function requiresInlineState(viewModel: GoalProgressViewModel | null | undefined): boolean {
+  return viewModel?.trackingPhase === "preparing";
+}
+
 function preparingViewMatchesGoalIdentity(
   viewModel: GoalProgressViewModel,
   goalIdentity: string | null,
@@ -625,7 +629,7 @@ export class SidecarMountController {
       host.hidden = uiPreference.hidden;
       host.requestedPlacement = requestedPlacement;
       host.placement =
-        preserveFallback || viewModel.trackingPhase === "preparing" ? "inline" : requestedPlacement;
+        preserveFallback || requiresInlineState(viewModel) ? "inline" : requestedPlacement;
       host.floatingXRatio = requestedFloatingXRatio;
     }
     if (host.placement !== "inline" || host.collapsed) {
@@ -776,7 +780,7 @@ export class SidecarMountController {
       this.#requestedPlacement === "inline" &&
       !threadChanged &&
       (this.#displayMode === "native" || this.#fallbackInlineOriginRetained);
-    host.placement = this.#requestedPlacement;
+    host.placement = requiresInlineState(host.viewModel) ? "inline" : this.#requestedPlacement;
     host.spaceConstrained = false;
     host.floatingPanelConstrained = false;
     const retainInlineOrigin =
@@ -1196,8 +1200,9 @@ export class SidecarMountController {
         ? composer.getBoundingClientRect()
         : null;
     const surfaceHeight =
-      host.shadowRoot?.querySelector<HTMLElement>(".floating-chip")?.getBoundingClientRect()
-        .height ?? 38;
+      host.shadowRoot
+        ?.querySelector<HTMLElement>(".floating-chip, .phase-error .state")
+        ?.getBoundingClientRect().height ?? 38;
     const fallbackBottom =
       view && composerRect
         ? Math.max(
@@ -1242,8 +1247,12 @@ export class SidecarMountController {
     if (!host) {
       return;
     }
+    // Preparing state uses normal height; errors retain the user's compact floating position.
+    if (requiresInlineState(host.viewModel)) {
+      host.placement = "inline";
+    }
     if (this.#displayMode === "fallback") {
-      host.placement = this.#requestedPlacement;
+      host.placement = requiresInlineState(host.viewModel) ? "inline" : this.#requestedPlacement;
       host.spaceConstrained = false;
       if (
         this.#fallbackInlineOriginRetained &&
@@ -1527,7 +1536,8 @@ export class SidecarMountController {
     const hostScale = this.#positionFloatingHost(host, left, targetTop, width);
     this.#floatingViewportTop = targetTop;
 
-    const chip = host.shadowRoot?.querySelector<HTMLElement>(".floating-chip") ?? null;
+    const chip =
+      host.shadowRoot?.querySelector<HTMLElement>(".floating-chip, .phase-error .state") ?? null;
     const panel = host.shadowRoot?.querySelector<HTMLElement>(".floating-panel") ?? null;
     if (
       host.floatingPanelConstrained &&
@@ -1538,7 +1548,13 @@ export class SidecarMountController {
       this.#scheduleFloatingLayout();
       return;
     }
-    if (!chip || (!host.collapsed && !host.floatingPanelConstrained && !panel)) {
+    if (
+      !chip ||
+      (host.viewModel?.trackingPhase !== "error" &&
+        !host.collapsed &&
+        !host.floatingPanelConstrained &&
+        !panel)
+    ) {
       return;
     }
     const chipRect = chip?.getBoundingClientRect() ?? null;
@@ -1706,7 +1722,7 @@ export class SidecarMountController {
 
   #retryFloatingPlacement(): void {
     const host = this.#host;
-    if (!host || this.#requestedPlacement !== "floating") {
+    if (!host || this.#requestedPlacement !== "floating" || requiresInlineState(host.viewModel)) {
       return;
     }
     this.#floatingFallbackActive = false;

--- a/runtime/source/packages/contracts/src/goal-contract.ts
+++ b/runtime/source/packages/contracts/src/goal-contract.ts
@@ -820,15 +820,19 @@ export const GoalProgressViewModelSchema = z
       });
     }
     const hasProgress = viewModel.overallProgressBps !== null && viewModel.overallPercent !== null;
-    const shouldHaveProgress =
+    const tracksProgress =
       viewModel.trackingPhase === "active" ||
       viewModel.trackingPhase === "paused" ||
       viewModel.trackingPhase === "blocked" ||
       viewModel.trackingPhase === "completed";
-    if (hasProgress !== shouldHaveProgress) {
+    if (
+      (viewModel.overallProgressBps === null) !== (viewModel.overallPercent === null) ||
+      (tracksProgress && !hasProgress) ||
+      (!tracksProgress && viewModel.trackingPhase !== "error" && hasProgress)
+    ) {
       context.addIssue({
         code: "custom",
-        message: "Progress is available only for tracking phases",
+        message: "Tracking views require progress; error views may retain confirmed progress",
         path: ["overallProgressBps"],
       });
     }

--- a/runtime/source/packages/contracts/src/page-host-version.json
+++ b/runtime/source/packages/contracts/src/page-host-version.json
@@ -1,0 +1,3 @@
+{
+  "pageHostVersion": 64
+}

--- a/runtime/source/packages/contracts/src/renderer-events.ts
+++ b/runtime/source/packages/contracts/src/renderer-events.ts
@@ -1,8 +1,9 @@
+import pageHostVersionManifest from "./page-host-version.json" with { type: "json" };
 import { GOAL_PROGRESS_RELEASE_VERSION } from "./release-version.js";
 import type { GoalProgressUiIntent } from "./ui-preference.js";
 
 export const GOAL_PROGRESS_ELEMENT_NAME = "codex-goal-progress";
-export const GOAL_PROGRESS_HOT_ELEMENT_NAME = `codex-goal-progress-v${GOAL_PROGRESS_RELEASE_VERSION.replaceAll(".", "-")}`;
+export const GOAL_PROGRESS_HOT_ELEMENT_NAME = `codex-goal-progress-v${GOAL_PROGRESS_RELEASE_VERSION.replaceAll(".", "-")}-p${pageHostVersionManifest.pageHostVersion}`;
 export const GOAL_PROGRESS_SET_COLLAPSED_EVENT = "goal-progress-set-collapsed";
 export const GOAL_PROGRESS_SET_MOTION_PAUSED_EVENT = "goal-progress-set-motion-paused";
 export const GOAL_PROGRESS_SET_PLACEMENT_EVENT = "goal-progress-set-placement";

--- a/runtime/source/packages/core/src/index.ts
+++ b/runtime/source/packages/core/src/index.ts
@@ -426,8 +426,8 @@ function viewPhase(
   contract: GoalContractAny,
   calculation: GoalProgressCalculation,
 ): Exclude<GoalProgressViewModel["trackingPhase"], "detached"> {
-  if (contract.phase === "preparing" || contract.phase === "error") {
-    return contract.phase;
+  if (contract.phase === "preparing") {
+    return "preparing";
   }
   if (calculation.completionConfirmed) {
     return "completed";
@@ -437,6 +437,9 @@ function viewPhase(
   }
   if (contract.nativeGoal.status === "blocked") {
     return "blocked";
+  }
+  if (contract.phase === "error" && contract.objectives.length === 0) {
+    return "error";
   }
   return "active";
 }
@@ -971,11 +974,11 @@ export function applyGoalProgressCommand(
   }
 
   if (command.type === "set-phase") {
-    if (command.phase === "paused") {
+    if (command.phase === "paused" || command.phase === "error") {
       return failure(
         "INVALID_TRANSITION",
         contract.revision,
-        "Pause state is read from the native Goal",
+        "Pause and error states are not model-controlled Contract phases",
       );
     }
     if (!validPhaseTransition(contract.phase, command.phase)) {

--- a/runtime/source/packages/host/src/index.ts
+++ b/runtime/source/packages/host/src/index.ts
@@ -1178,20 +1178,17 @@ export class GoalProgressHelper {
     code: string,
   ): Promise<GoalProgressViewModel> {
     const threadId = this.#threadIdOf(contract);
+    const {
+      blockedReason: _blockedReason,
+      token: _token,
+      ...confirmed
+    } = projectContract(contract);
     const viewModel = GoalProgressViewModelSchema.parse({
-      schemaVersion: 2,
-      contractId: contract.contractId,
-      sessionId: threadId,
-      revision: contract.revision,
-      scopeRevision: contract.scopeRevision,
+      ...confirmed,
       trackingPhase: "error",
-      objective: contract.nativeGoal.objective,
-      overallProgressBps: null,
-      overallPercent: null,
       finalVerificationPending: false,
       objectives: [],
       optionalObjectives: [],
-      maxVisibleObjectives: 3,
       errorCode: code,
     });
     await this.#publishVerified(threadId, viewModel);

--- a/runtime/source/packages/mcp/src/index.ts
+++ b/runtime/source/packages/mcp/src/index.ts
@@ -141,7 +141,7 @@ export const GoalProgressRescopeInputSchema = z
   .passthrough()
   .meta({ required: ["contractId", "expectedRevision", "reason", "objectives"] });
 
-const GoalProgressModelPhaseSchema = GoalProgressPhaseSchema.exclude(["paused"]);
+const GoalProgressModelPhaseSchema = GoalProgressPhaseSchema.exclude(["paused", "error"]);
 
 export const GoalProgressSetPhaseInputSchema = z
   .object({
@@ -1014,7 +1014,7 @@ export function createGoalProgressMcpServer(options: GoalProgressMcpServerOption
     {
       title: "Set Goal Progress Phase",
       description:
-        "Set preparing, active, completed, or error. Do not use it to pause; native pause is read-only.",
+        "Set preparing, active, or completed. Do not report task failures as plugin errors; native pause is read-only. Use native Goal for blockers.",
       inputSchema: GoalProgressSetPhaseInputSchema,
       outputSchema: GoalProgressToolOutputSchema,
       annotations: {

--- a/runtime/source/packages/renderer/src/components/states.ts
+++ b/runtime/source/packages/renderer/src/components/states.ts
@@ -29,34 +29,32 @@ export function renderErrorView(
   onDetach: () => void,
   messages: GoalProgressMessages,
 ) {
-  const errorCode = viewModel?.errorCode ?? "VIEW_MODEL_UNAVAILABLE";
+  const summary =
+    viewModel?.overallPercent === null || viewModel?.overallPercent === undefined
+      ? messages.unavailableTitle
+      : `${viewModel.overallPercent}% · ${messages.unavailableTitle}`;
   return html`
-    <div class="state" role="alert">
-      <div>
-        <div class="state-symbol error" aria-hidden="true">!</div>
-        <div class="state-title">${messages.unavailableTitle}</div>
-        <div class="state-copy">${messages.unavailableCopy}</div>
-        <code class="error-code">${errorCode}</code>
-        <div class="state-actions">
-          <button
-            class="icon-button retry-button"
-            type="button"
-            aria-label=${messages.retryProgress}
-            title=${messages.retry}
-            @click=${onRetry}
-          >
-            ↻
-          </button>
-          <button
-            class="icon-button detach-button"
-            type="button"
-            aria-label=${messages.closeProgress}
-            title=${messages.closeProgress}
-            @click=${onDetach}
-          >
-            ×
-          </button>
-        </div>
+    <div class="state error" role="alert">
+      <span class="error-summary">${summary}</span>
+      <div class="state-actions">
+        <button
+          class="retry-button"
+          type="button"
+          aria-label=${messages.retryProgress}
+          title=${messages.retry}
+          @click=${onRetry}
+        >
+          ${messages.retry}
+        </button>
+        <button
+          class="icon-button detach-button"
+          type="button"
+          aria-label=${messages.closeProgress}
+          title=${messages.closeProgress}
+          @click=${onDetach}
+        >
+          ×
+        </button>
       </div>
     </div>
   `;

--- a/runtime/source/packages/renderer/src/goal-progress-element.ts
+++ b/runtime/source/packages/renderer/src/goal-progress-element.ts
@@ -486,7 +486,7 @@ export class GoalProgressElement extends LitElement {
     const viewModel = this.viewModel;
     const locale = resolveGoalProgressLocale(this.locale);
     if (!viewModel) {
-      return html`<section class="panel phase-error">
+      return html`<section class="panel phase-error placement-${this.placement}">
         ${renderErrorView(null, this.#requestRetry, this.#requestDetach, locale.messages)}
       </section>`;
     }
@@ -496,7 +496,7 @@ export class GoalProgressElement extends LitElement {
       </section>`;
     }
     if (viewModel.trackingPhase === "error") {
-      return html`<section class="panel phase-error">
+      return html`<section class="panel phase-error placement-${this.placement}">
         ${renderErrorView(viewModel, this.#requestRetry, this.#requestDetach, locale.messages)}
       </section>`;
     }

--- a/runtime/source/packages/renderer/src/locales/am.ts
+++ b/runtime/source/packages/renderer/src/locales/am.ts
@@ -74,7 +74,7 @@ export const amMessages: GoalProgressMessages = {
   preparingBaseline: "የሂደት መነሻ በማዘጋጀት ላይ…",
   preparingObjectives: "የመቀበያ ነጥቦችን በማዘጋጀት ላይ…",
   preparingCopy: "የአሁኑ ሞዴል Goalን እና የመቀበያ ዝርዝሩን እየፈተሸ ነው።",
-  unavailableTitle: "የGoal ሂደት ለጊዜው አይገኝም",
+  unavailableTitle: "ሂደቱ አልተዘመነም",
   unavailableCopy: "Goal መቀጠል ይችላል። ግንኙነቱ ሲመለስ ሂደቱ እንደገና ይታያል።",
   retryProgress: "ሂደቱን እንደገና ሞክር",
   retry: "እንደገና ሞክር",

--- a/runtime/source/packages/renderer/src/locales/ar.ts
+++ b/runtime/source/packages/renderer/src/locales/ar.ts
@@ -74,7 +74,7 @@ export const arMessages: GoalProgressMessages = {
   preparingBaseline: "جارٍ إنشاء خط أساس للتقدم…",
   preparingObjectives: "جارٍ إعداد نقاط القبول…",
   preparingCopy: "يتحقق النموذج الحالي من الهدف وقائمة القبول.",
-  unavailableTitle: "تقدم الهدف غير متاح",
+  unavailableTitle: "لم يُحدَّث التقدم",
   unavailableCopy: "يمكن أن يستمر Goal. سيظهر التقدم مجددًا بعد استعادة الاتصال.",
   retryProgress: "إعادة محاولة التقدم",
   retry: "إعادة المحاولة",

--- a/runtime/source/packages/renderer/src/locales/bg.ts
+++ b/runtime/source/packages/renderer/src/locales/bg.ts
@@ -74,7 +74,7 @@ export const bgMessages: GoalProgressMessages = {
   preparingBaseline: "Създаване на начална база за напредъка…",
   preparingObjectives: "Подготовка на критериите за приемане…",
   preparingCopy: "Текущият модел проверява Goal и списъка с критерии.",
-  unavailableTitle: "Напредъкът по Goal не е достъпен",
+  unavailableTitle: "Напредъкът не е актуализиран",
   unavailableCopy: "Goal може да продължи. Напредъкът ще се върне след възстановяване на връзката.",
   retryProgress: "Повтори напредъка",
   retry: "Повтори",

--- a/runtime/source/packages/renderer/src/locales/bn.ts
+++ b/runtime/source/packages/renderer/src/locales/bn.ts
@@ -74,7 +74,7 @@ export const bnMessages: GoalProgressMessages = {
   preparingBaseline: "অগ্রগতির ভিত্তি তৈরি হচ্ছে…",
   preparingObjectives: "গ্রহণযোগ্যতার ধাপ প্রস্তুত হচ্ছে…",
   preparingCopy: "বর্তমান মডেল Goal ও গ্রহণযোগ্যতার তালিকা যাচাই করছে।",
-  unavailableTitle: "Goal-এর অগ্রগতি পাওয়া যাচ্ছে না",
+  unavailableTitle: "অগ্রগতি হালনাগাদ হয়নি",
   unavailableCopy: "Goal চলতে পারে। সংযোগ ফিরলে অগ্রগতি আবার দেখা যাবে।",
   retryProgress: "অগ্রগতি আবার চেষ্টা করুন",
   retry: "আবার চেষ্টা করুন",

--- a/runtime/source/packages/renderer/src/locales/bs.ts
+++ b/runtime/source/packages/renderer/src/locales/bs.ts
@@ -74,7 +74,7 @@ export const bsMessages: GoalProgressMessages = {
   preparingBaseline: "Postavljanje početne vrijednosti napretka…",
   preparingObjectives: "Priprema tačaka prihvatanja…",
   preparingCopy: "Trenutni model provjerava Goal i listu prihvatanja.",
-  unavailableTitle: "Napredak Goal-a nije dostupan",
+  unavailableTitle: "Napredak nije ažuriran",
   unavailableCopy: "Goal može nastaviti. Napredak će se vratiti kada se veza oporavi.",
   retryProgress: "Ponovi učitavanje napretka",
   retry: "Pokušaj ponovo",

--- a/runtime/source/packages/renderer/src/locales/ca.ts
+++ b/runtime/source/packages/renderer/src/locales/ca.ts
@@ -74,7 +74,7 @@ export const caMessages: GoalProgressMessages = {
   preparingBaseline: "S'està establint la base del progrés…",
   preparingObjectives: "S'estan preparant els punts d'acceptació…",
   preparingCopy: "El model actual està comprovant el Goal i la llista d'acceptació.",
-  unavailableTitle: "El progrés del Goal no està disponible",
+  unavailableTitle: "Progrés sense actualitzar",
   unavailableCopy: "El Goal pot continuar. El progrés tornarà quan es recuperi la connexió.",
   retryProgress: "Torna a provar el progrés",
   retry: "Torna-ho a provar",

--- a/runtime/source/packages/renderer/src/locales/cs.ts
+++ b/runtime/source/packages/renderer/src/locales/cs.ts
@@ -74,7 +74,7 @@ export const csMessages: GoalProgressMessages = {
   preparingBaseline: "Nastavování výchozího stavu průběhu…",
   preparingObjectives: "Příprava bodů přijetí…",
   preparingCopy: "Aktuální model kontroluje Goal a kontrolní seznam přijetí.",
-  unavailableTitle: "Průběh Goal není dostupný",
+  unavailableTitle: "Průběh není aktualizován",
   unavailableCopy: "Goal může pokračovat. Průběh se vrátí po obnovení připojení.",
   retryProgress: "Zkusit průběh znovu",
   retry: "Zkusit znovu",

--- a/runtime/source/packages/renderer/src/locales/da.ts
+++ b/runtime/source/packages/renderer/src/locales/da.ts
@@ -74,7 +74,7 @@ export const daMessages: GoalProgressMessages = {
   preparingBaseline: "Opretter udgangspunkt for fremdrift…",
   preparingObjectives: "Forbereder godkendelsespunkter…",
   preparingCopy: "Den aktuelle model kontrollerer Goal og godkendelseslisten.",
-  unavailableTitle: "Goal-fremdrift er ikke tilgængelig",
+  unavailableTitle: "Fremskridt ikke opdateret",
   unavailableCopy:
     "Goal kan fortsætte. Fremdriften vender tilbage, når forbindelsen er genoprettet.",
   retryProgress: "Prøv fremdrift igen",

--- a/runtime/source/packages/renderer/src/locales/de.ts
+++ b/runtime/source/packages/renderer/src/locales/de.ts
@@ -74,7 +74,7 @@ export const deMessages: GoalProgressMessages = {
   preparingBaseline: "Fortschrittsbasis wird erstellt…",
   preparingObjectives: "Abnahmepunkte werden vorbereitet…",
   preparingCopy: "Das aktuelle Modell prüft das Goal und die Abnahmeliste.",
-  unavailableTitle: "Goal-Fortschritt ist nicht verfügbar",
+  unavailableTitle: "Fortschritt nicht aktualisiert",
   unavailableCopy:
     "Das Goal kann fortgesetzt werden. Der Fortschritt erscheint nach Wiederherstellung der Verbindung.",
   retryProgress: "Fortschritt erneut laden",

--- a/runtime/source/packages/renderer/src/locales/el.ts
+++ b/runtime/source/packages/renderer/src/locales/el.ts
@@ -74,7 +74,7 @@ export const elMessages: GoalProgressMessages = {
   preparingBaseline: "Δημιουργία βάσης προόδου…",
   preparingObjectives: "Προετοιμασία σημείων αποδοχής…",
   preparingCopy: "Το τρέχον μοντέλο ελέγχει το Goal και τη λίστα αποδοχής.",
-  unavailableTitle: "Η πρόοδος του Goal δεν είναι διαθέσιμη",
+  unavailableTitle: "Η πρόοδος δεν ενημερώθηκε",
   unavailableCopy:
     "Το Goal μπορεί να συνεχίσει. Η πρόοδος θα επανέλθει όταν αποκατασταθεί η σύνδεση.",
   retryProgress: "Επανάληψη προόδου",

--- a/runtime/source/packages/renderer/src/locales/en.ts
+++ b/runtime/source/packages/renderer/src/locales/en.ts
@@ -74,7 +74,7 @@ export const enMessages: GoalProgressMessages = {
   preparingBaseline: "Establishing the progress baseline…",
   preparingObjectives: "Preparing acceptance points…",
   preparingCopy: "The current model is checking the Goal and acceptance checklist.",
-  unavailableTitle: "Goal progress is unavailable",
+  unavailableTitle: "Progress not updated",
   unavailableCopy: "The Goal can continue. Progress will return when the connection recovers.",
   retryProgress: "Retry progress",
   retry: "Retry",

--- a/runtime/source/packages/renderer/src/locales/es-419.ts
+++ b/runtime/source/packages/renderer/src/locales/es-419.ts
@@ -74,7 +74,7 @@ export const es419Messages: GoalProgressMessages = {
   preparingBaseline: "Creando la base del progreso…",
   preparingObjectives: "Preparando los puntos de aceptación…",
   preparingCopy: "El modelo actual está revisando el Goal y la lista de aceptación.",
-  unavailableTitle: "El progreso del Goal no está disponible",
+  unavailableTitle: "Progreso sin actualizar",
   unavailableCopy: "El Goal puede continuar. El progreso volverá cuando se recupere la conexión.",
   retryProgress: "Volver a cargar el progreso",
   retry: "Volver a intentar",

--- a/runtime/source/packages/renderer/src/locales/es-es.ts
+++ b/runtime/source/packages/renderer/src/locales/es-es.ts
@@ -74,7 +74,7 @@ export const esESMessages: GoalProgressMessages = {
   preparingBaseline: "Estableciendo la base del progreso…",
   preparingObjectives: "Preparando los puntos de aceptación…",
   preparingCopy: "El modelo actual está comprobando el Goal y la lista de aceptación.",
-  unavailableTitle: "El progreso del Goal no está disponible",
+  unavailableTitle: "Progreso sin actualizar",
   unavailableCopy: "El Goal puede continuar. El progreso volverá cuando se recupere la conexión.",
   retryProgress: "Volver a cargar el progreso",
   retry: "Volver a intentarlo",

--- a/runtime/source/packages/renderer/src/locales/et.ts
+++ b/runtime/source/packages/renderer/src/locales/et.ts
@@ -74,7 +74,7 @@ export const etMessages: GoalProgressMessages = {
   preparingBaseline: "Edenemise lähtepunkti loomine…",
   preparingObjectives: "Vastuvõtupunktide ettevalmistamine…",
   preparingCopy: "Praegune mudel kontrollib Goal-i ja vastuvõtuloendit.",
-  unavailableTitle: "Goal-i edenemine pole saadaval",
+  unavailableTitle: "Edenemine pole uuendatud",
   unavailableCopy: "Goal võib jätkata. Edenemine taastub koos ühendusega.",
   retryProgress: "Proovi edenemist uuesti",
   retry: "Proovi uuesti",

--- a/runtime/source/packages/renderer/src/locales/fa.ts
+++ b/runtime/source/packages/renderer/src/locales/fa.ts
@@ -74,7 +74,7 @@ export const faMessages: GoalProgressMessages = {
   preparingBaseline: "در حال تعیین مبنای پیشرفت…",
   preparingObjectives: "در حال آماده‌سازی معیارهای پذیرش…",
   preparingCopy: "مدل فعلی در حال بررسی Goal و فهرست پذیرش است.",
-  unavailableTitle: "پیشرفت Goal در دسترس نیست",
+  unavailableTitle: "پیشرفت به‌روز نشده",
   unavailableCopy: "Goal می‌تواند ادامه یابد. با بازیابی اتصال، پیشرفت دوباره نمایش داده می‌شود.",
   retryProgress: "تلاش دوباره برای پیشرفت",
   retry: "تلاش دوباره",

--- a/runtime/source/packages/renderer/src/locales/fi.ts
+++ b/runtime/source/packages/renderer/src/locales/fi.ts
@@ -74,7 +74,7 @@ export const fiMessages: GoalProgressMessages = {
   preparingBaseline: "Luodaan edistymisen lähtötasoa…",
   preparingObjectives: "Valmistellaan hyväksymiskohtia…",
   preparingCopy: "Nykyinen malli tarkistaa Goalin ja hyväksymisluettelon.",
-  unavailableTitle: "Goalin edistyminen ei ole saatavilla",
+  unavailableTitle: "Edistymistä ei ole päivitetty",
   unavailableCopy: "Goal voi jatkua. Edistyminen palaa, kun yhteys palautuu.",
   retryProgress: "Yritä edistymistä uudelleen",
   retry: "Yritä uudelleen",

--- a/runtime/source/packages/renderer/src/locales/fr-ca.ts
+++ b/runtime/source/packages/renderer/src/locales/fr-ca.ts
@@ -74,7 +74,7 @@ export const frCAMessages: GoalProgressMessages = {
   preparingBaseline: "Création du point de référence…",
   preparingObjectives: "Préparation des critères d’acceptation…",
   preparingCopy: "Le modèle actuel vérifie le Goal et la liste d’acceptation.",
-  unavailableTitle: "La progression du Goal est indisponible",
+  unavailableTitle: "Progression non actualisée",
   unavailableCopy: "Le Goal peut continuer. La progression reviendra avec la connexion.",
   retryProgress: "Réessayer la progression",
   retry: "Réessayer",

--- a/runtime/source/packages/renderer/src/locales/fr-fr.ts
+++ b/runtime/source/packages/renderer/src/locales/fr-fr.ts
@@ -74,7 +74,7 @@ export const frFRMessages: GoalProgressMessages = {
   preparingBaseline: "Création du niveau de référence…",
   preparingObjectives: "Préparation des critères d’acceptation…",
   preparingCopy: "Le modèle actuel vérifie le Goal et la liste d’acceptation.",
-  unavailableTitle: "La progression du Goal est indisponible",
+  unavailableTitle: "Progression non actualisée",
   unavailableCopy: "Le Goal peut continuer. La progression reviendra avec la connexion.",
   retryProgress: "Réessayer la progression",
   retry: "Réessayer",

--- a/runtime/source/packages/renderer/src/locales/gu.ts
+++ b/runtime/source/packages/renderer/src/locales/gu.ts
@@ -74,7 +74,7 @@ export const guMessages: GoalProgressMessages = {
   preparingBaseline: "પ્રગતિનો આધાર તૈયાર થઈ રહ્યો છે…",
   preparingObjectives: "સ્વીકૃતિ મુદ્દા તૈયાર થઈ રહ્યા છે…",
   preparingCopy: "વર્તમાન મોડેલ Goal અને સ્વીકૃતિ યાદી તપાસી રહ્યું છે.",
-  unavailableTitle: "Goal પ્રગતિ ઉપલબ્ધ નથી",
+  unavailableTitle: "પ્રગતિ અપડેટ થઈ નથી",
   unavailableCopy: "Goal ચાલુ રહી શકે છે. કનેક્શન પાછું આવે ત્યારે પ્રગતિ ફરી દેખાશે.",
   retryProgress: "પ્રગતિ ફરી અજમાવો",
   retry: "ફરી અજમાવો",

--- a/runtime/source/packages/renderer/src/locales/hi.ts
+++ b/runtime/source/packages/renderer/src/locales/hi.ts
@@ -74,7 +74,7 @@ export const hiMessages: GoalProgressMessages = {
   preparingBaseline: "प्रगति का आधार तैयार हो रहा है…",
   preparingObjectives: "स्वीकृति बिंदु तैयार हो रहे हैं…",
   preparingCopy: "वर्तमान मॉडल Goal और स्वीकृति सूची की जाँच कर रहा है।",
-  unavailableTitle: "Goal की प्रगति उपलब्ध नहीं है",
+  unavailableTitle: "प्रगति अपडेट नहीं हुई",
   unavailableCopy: "Goal जारी रह सकता है। कनेक्शन लौटने पर प्रगति फिर दिखेगी।",
   retryProgress: "प्रगति फिर आज़माएँ",
   retry: "फिर आज़माएँ",

--- a/runtime/source/packages/renderer/src/locales/hr.ts
+++ b/runtime/source/packages/renderer/src/locales/hr.ts
@@ -74,7 +74,7 @@ export const hrMessages: GoalProgressMessages = {
   preparingBaseline: "Postavljanje početnog stanja napretka…",
   preparingObjectives: "Priprema točaka prihvaćanja…",
   preparingCopy: "Trenutačni model provjerava Goal i popis prihvaćanja.",
-  unavailableTitle: "Napredak Goala nije dostupan",
+  unavailableTitle: "Napredak nije ažuriran",
   unavailableCopy: "Goal se može nastaviti. Napredak će se vratiti kad se veza obnovi.",
   retryProgress: "Ponovi dohvat napretka",
   retry: "Pokušaj ponovno",

--- a/runtime/source/packages/renderer/src/locales/hu.ts
+++ b/runtime/source/packages/renderer/src/locales/hu.ts
@@ -74,7 +74,7 @@ export const huMessages: GoalProgressMessages = {
   preparingBaseline: "Előrehaladási alapérték létrehozása…",
   preparingObjectives: "Elfogadási pontok előkészítése…",
   preparingCopy: "A jelenlegi modell ellenőrzi a Goalt és az elfogadási listát.",
-  unavailableTitle: "A Goal előrehaladása nem érhető el",
+  unavailableTitle: "Az előrehaladás nem frissült",
   unavailableCopy: "A Goal folytatódhat. Az előrehaladás a kapcsolat helyreállásakor visszatér.",
   retryProgress: "Előrehaladás újrapróbálása",
   retry: "Újra",

--- a/runtime/source/packages/renderer/src/locales/hy.ts
+++ b/runtime/source/packages/renderer/src/locales/hy.ts
@@ -74,7 +74,7 @@ export const hyMessages: GoalProgressMessages = {
   preparingBaseline: "Առաջընթացի հիմքը ստեղծվում է…",
   preparingObjectives: "Ընդունման կետերը պատրաստվում են…",
   preparingCopy: "Ընթացիկ մոդելը ստուգում է Goal-ը և ընդունման ցանկը։",
-  unavailableTitle: "Goal-ի առաջընթացը հասանելի չէ",
+  unavailableTitle: "Առաջընթացը չի թարմացվել",
   unavailableCopy: "Goal-ը կարող է շարունակվել։ Կապը վերականգնվելիս առաջընթացը կվերադառնա։",
   retryProgress: "Կրկին փորձել առաջընթացը",
   retry: "Կրկին փորձել",

--- a/runtime/source/packages/renderer/src/locales/id.ts
+++ b/runtime/source/packages/renderer/src/locales/id.ts
@@ -74,7 +74,7 @@ export const idMessages: GoalProgressMessages = {
   preparingBaseline: "Menyiapkan patokan progres…",
   preparingObjectives: "Menyiapkan poin penerimaan…",
   preparingCopy: "Model saat ini sedang memeriksa Goal dan daftar penerimaan.",
-  unavailableTitle: "Progres Goal tidak tersedia",
+  unavailableTitle: "Progres belum diperbarui",
   unavailableCopy: "Goal dapat terus berjalan. Progres akan kembali saat koneksi pulih.",
   retryProgress: "Coba lagi progres",
   retry: "Coba lagi",

--- a/runtime/source/packages/renderer/src/locales/is.ts
+++ b/runtime/source/packages/renderer/src/locales/is.ts
@@ -74,7 +74,7 @@ export const isISMessages: GoalProgressMessages = {
   preparingBaseline: "Stofnar framvindugrunn…",
   preparingObjectives: "Undirbýr staðfestingaratriði…",
   preparingCopy: "Núverandi líkan yfirfer markmiðið og gátlistann.",
-  unavailableTitle: "Framvinda markmiðs er ekki tiltæk",
+  unavailableTitle: "Framvinda ekki uppfærð",
   unavailableCopy: "Goal getur haldið áfram. Framvindan birtist aftur þegar tengingin batnar.",
   retryProgress: "Reyna framvindu aftur",
   retry: "Reyna aftur",

--- a/runtime/source/packages/renderer/src/locales/it.ts
+++ b/runtime/source/packages/renderer/src/locales/it.ts
@@ -74,7 +74,7 @@ export const itMessages: GoalProgressMessages = {
   preparingBaseline: "Creazione del riferimento di avanzamento…",
   preparingObjectives: "Preparazione dei punti di accettazione…",
   preparingCopy: "Il modello attuale sta controllando il Goal e l’elenco di accettazione.",
-  unavailableTitle: "Avanzamento del Goal non disponibile",
+  unavailableTitle: "Avanzamento non aggiornato",
   unavailableCopy:
     "Il Goal può continuare. L’avanzamento tornerà quando la connessione sarà ripristinata.",
   retryProgress: "Riprova avanzamento",

--- a/runtime/source/packages/renderer/src/locales/ja.ts
+++ b/runtime/source/packages/renderer/src/locales/ja.ts
@@ -74,7 +74,7 @@ export const jaMessages: GoalProgressMessages = {
   preparingBaseline: "進捗の基準を作成中…",
   preparingObjectives: "確認項目を準備中…",
   preparingCopy: "現在のモデルが Goal と確認リストを確認しています。",
-  unavailableTitle: "Goal の進捗を表示できません",
+  unavailableTitle: "進捗は未更新です",
   unavailableCopy: "Goal は続行できます。接続が戻ると進捗も再表示されます。",
   retryProgress: "進捗を再読み込み",
   retry: "再試行",

--- a/runtime/source/packages/renderer/src/locales/ka.ts
+++ b/runtime/source/packages/renderer/src/locales/ka.ts
@@ -74,7 +74,7 @@ export const kaMessages: GoalProgressMessages = {
   preparingBaseline: "პროგრესის საწყისი დონე მზადდება…",
   preparingObjectives: "მიღების პუნქტები მზადდება…",
   preparingCopy: "მიმდინარე მოდელი ამოწმებს Goal-ს და მიღების სიას.",
-  unavailableTitle: "Goal-ის პროგრესი მიუწვდომელია",
+  unavailableTitle: "პროგრესი არ განახლებულა",
   unavailableCopy: "Goal შეიძლება გაგრძელდეს. პროგრესი დაბრუნდება კავშირის აღდგენისას.",
   retryProgress: "პროგრესის ხელახლა ცდა",
   retry: "ხელახლა ცდა",

--- a/runtime/source/packages/renderer/src/locales/kk.ts
+++ b/runtime/source/packages/renderer/src/locales/kk.ts
@@ -74,7 +74,7 @@ export const kkMessages: GoalProgressMessages = {
   preparingBaseline: "Прогресс негізі құрылуда…",
   preparingObjectives: "Қабылдау тармақтары дайындалуда…",
   preparingCopy: "Ағымдағы модель Goal мен қабылдау тізімін тексеріп жатыр.",
-  unavailableTitle: "Goal прогресі қолжетімсіз",
+  unavailableTitle: "Прогресс жаңартылмаған",
   unavailableCopy:
     "Goal жұмысын жалғастыра алады. Байланыс қалпына келгенде прогресс қайта көрсетіледі.",
   retryProgress: "Прогресті қайталау",

--- a/runtime/source/packages/renderer/src/locales/kn.ts
+++ b/runtime/source/packages/renderer/src/locales/kn.ts
@@ -74,7 +74,7 @@ export const knMessages: GoalProgressMessages = {
   preparingBaseline: "ಪ್ರಗತಿಯ ಮೂಲ ಸ್ಥಿತಿ ಸಿದ್ಧವಾಗುತ್ತಿದೆ…",
   preparingObjectives: "ಸ್ವೀಕಾರ ಅಂಶಗಳು ಸಿದ್ಧವಾಗುತ್ತಿವೆ…",
   preparingCopy: "ಪ್ರಸ್ತುತ ಮಾದರಿ Goal ಮತ್ತು ಸ್ವೀಕಾರ ಪಟ್ಟಿಯನ್ನು ಪರಿಶೀಲಿಸುತ್ತಿದೆ.",
-  unavailableTitle: "Goal ಪ್ರಗತಿ ಲಭ್ಯವಿಲ್ಲ",
+  unavailableTitle: "ಪ್ರಗತಿ ನವೀಕರಿಸಲಾಗಿಲ್ಲ",
   unavailableCopy: "Goal ಮುಂದುವರಿಯಬಹುದು. ಸಂಪರ್ಕ ಮರಳಿದಾಗ ಪ್ರಗತಿ ಮತ್ತೆ ಕಾಣಿಸುತ್ತದೆ.",
   retryProgress: "ಪ್ರಗತಿಯನ್ನು ಮರುಪ್ರಯತ್ನಿಸಿ",
   retry: "ಮರುಪ್ರಯತ್ನಿಸಿ",

--- a/runtime/source/packages/renderer/src/locales/ko.ts
+++ b/runtime/source/packages/renderer/src/locales/ko.ts
@@ -74,7 +74,7 @@ export const koMessages: GoalProgressMessages = {
   preparingBaseline: "진행 기준 설정 중…",
   preparingObjectives: "확인 항목 준비 중…",
   preparingCopy: "현재 모델이 Goal과 확인 목록을 검토하고 있습니다.",
-  unavailableTitle: "Goal 진행률을 사용할 수 없습니다",
+  unavailableTitle: "진행률이 갱신되지 않음",
   unavailableCopy: "Goal은 계속 진행할 수 있습니다. 연결이 복구되면 진행률이 다시 표시됩니다.",
   retryProgress: "진행률 다시 시도",
   retry: "다시 시도",

--- a/runtime/source/packages/renderer/src/locales/lt.ts
+++ b/runtime/source/packages/renderer/src/locales/lt.ts
@@ -74,7 +74,7 @@ export const ltMessages: GoalProgressMessages = {
   preparingBaseline: "Kuriamas eigos atskaitos taškas…",
   preparingObjectives: "Ruošiami priėmimo punktai…",
   preparingCopy: "Dabartinis modelis tikrina Goal ir priėmimo sąrašą.",
-  unavailableTitle: "Goal eiga nepasiekiama",
+  unavailableTitle: "Eiga neatnaujinta",
   unavailableCopy: "Goal gali būti tęsiamas. Atkūrus ryšį eiga vėl bus rodoma.",
   retryProgress: "Bandyti eigą dar kartą",
   retry: "Bandyti dar kartą",

--- a/runtime/source/packages/renderer/src/locales/lv.ts
+++ b/runtime/source/packages/renderer/src/locales/lv.ts
@@ -74,7 +74,7 @@ export const lvMessages: GoalProgressMessages = {
   preparingBaseline: "Veido progresa atskaites punktu…",
   preparingObjectives: "Gatavo pieņemšanas punktus…",
   preparingCopy: "Pašreizējais modelis pārbauda Goal un pieņemšanas sarakstu.",
-  unavailableTitle: "Goal progress nav pieejams",
+  unavailableTitle: "Progress nav atjaunināts",
   unavailableCopy:
     "Goal var turpināt darbu. Kad savienojums atjaunosies, progress atkal būs redzams.",
   retryProgress: "Mēģināt progresu vēlreiz",

--- a/runtime/source/packages/renderer/src/locales/mk.ts
+++ b/runtime/source/packages/renderer/src/locales/mk.ts
@@ -74,7 +74,7 @@ export const mkMessages: GoalProgressMessages = {
   preparingBaseline: "Се поставува почетната состојба на напредокот…",
   preparingObjectives: "Се подготвуваат точки за прифаќање…",
   preparingCopy: "Тековниот модел ги проверува Goal и списокот за прифаќање.",
-  unavailableTitle: "Напредокот на Goal не е достапен",
+  unavailableTitle: "Напредокот не е ажуриран",
   unavailableCopy: "Goal може да продолжи. Напредокот ќе се врати кога ќе се обнови врската.",
   retryProgress: "Обиди се повторно за напредокот",
   retry: "Обиди се повторно",

--- a/runtime/source/packages/renderer/src/locales/ml.ts
+++ b/runtime/source/packages/renderer/src/locales/ml.ts
@@ -74,7 +74,7 @@ export const mlMessages: GoalProgressMessages = {
   preparingBaseline: "പുരോഗതി അടിസ്ഥാനരേഖ തയ്യാറാക്കുന്നു…",
   preparingObjectives: "അംഗീകാര ഇനങ്ങൾ തയ്യാറാക്കുന്നു…",
   preparingCopy: "നിലവിലെ മോഡൽ Goal-ഉം അംഗീകാര പട്ടികയും പരിശോധിക്കുന്നു.",
-  unavailableTitle: "Goal പുരോഗതി ലഭ്യമല്ല",
+  unavailableTitle: "പുരോഗതി പുതുക്കിയിട്ടില്ല",
   unavailableCopy: "Goal തുടരാം. കണക്ഷൻ വീണ്ടെടുക്കുമ്പോൾ പുരോഗതി വീണ്ടും കാണിക്കും.",
   retryProgress: "പുരോഗതി വീണ്ടും ശ്രമിക്കുക",
   retry: "വീണ്ടും ശ്രമിക്കുക",

--- a/runtime/source/packages/renderer/src/locales/mn.ts
+++ b/runtime/source/packages/renderer/src/locales/mn.ts
@@ -74,7 +74,7 @@ export const mnMessages: GoalProgressMessages = {
   preparingBaseline: "Явцын суурь түвшинг тогтоож байна…",
   preparingObjectives: "Хүлээн авах зүйлсийг бэлдэж байна…",
   preparingCopy: "Одоогийн загвар Goal болон хүлээн авах жагсаалтыг шалгаж байна.",
-  unavailableTitle: "Goal явц боломжгүй",
+  unavailableTitle: "Явц шинэчлэгдээгүй",
   unavailableCopy: "Goal үргэлжлүүлэн ажиллаж болно. Холболт сэргэхэд явц дахин харагдана.",
   retryProgress: "Явцыг дахин оролдох",
   retry: "Дахин оролдох",

--- a/runtime/source/packages/renderer/src/locales/mr.ts
+++ b/runtime/source/packages/renderer/src/locales/mr.ts
@@ -74,7 +74,7 @@ export const mrMessages: GoalProgressMessages = {
   preparingBaseline: "प्रगतीचा आधार तयार करत आहे…",
   preparingObjectives: "स्वीकृती मुद्दे तयार करत आहे…",
   preparingCopy: "सध्याचे मॉडेल Goal आणि स्वीकृती सूची तपासत आहे.",
-  unavailableTitle: "Goal प्रगती उपलब्ध नाही",
+  unavailableTitle: "प्रगती अपडेट झालेली नाही",
   unavailableCopy: "Goal सुरू राहू शकते. कनेक्शन पूर्ववत झाल्यावर प्रगती पुन्हा दिसेल.",
   retryProgress: "प्रगतीसाठी पुन्हा प्रयत्न करा",
   retry: "पुन्हा प्रयत्न करा",

--- a/runtime/source/packages/renderer/src/locales/ms.ts
+++ b/runtime/source/packages/renderer/src/locales/ms.ts
@@ -74,7 +74,7 @@ export const msMessages: GoalProgressMessages = {
   preparingBaseline: "Menetapkan garis dasar kemajuan…",
   preparingObjectives: "Menyediakan perkara penerimaan…",
   preparingCopy: "Model semasa sedang menyemak Goal dan senarai penerimaan.",
-  unavailableTitle: "Kemajuan Goal tidak tersedia",
+  unavailableTitle: "Kemajuan belum dikemas kini",
   unavailableCopy: "Goal boleh diteruskan. Kemajuan akan muncul semula apabila sambungan pulih.",
   retryProgress: "Cuba semula kemajuan",
   retry: "Cuba lagi",

--- a/runtime/source/packages/renderer/src/locales/my.ts
+++ b/runtime/source/packages/renderer/src/locales/my.ts
@@ -74,7 +74,7 @@ export const myMessages: GoalProgressMessages = {
   preparingBaseline: "တိုးတက်မှု အခြေခံအမှတ် သတ်မှတ်နေသည်…",
   preparingObjectives: "လက်ခံချက်များ ပြင်ဆင်နေသည်…",
   preparingCopy: "လက်ရှိမော်ဒယ်သည် Goal နှင့် လက်ခံချက်စာရင်းကို စစ်ဆေးနေသည်။",
-  unavailableTitle: "Goal တိုးတက်မှု မရရှိနိုင်ပါ",
+  unavailableTitle: "တိုးတက်မှုကို မွမ်းမံမထားသေးပါ",
   unavailableCopy: "Goal ကို ဆက်လုပ်နိုင်သည်။ ချိတ်ဆက်မှု ပြန်ရသောအခါ တိုးတက်မှုကို ပြန်ပြမည်။",
   retryProgress: "တိုးတက်မှုကို ပြန်စမ်းရန်",
   retry: "ပြန်စမ်းရန်",

--- a/runtime/source/packages/renderer/src/locales/nb.ts
+++ b/runtime/source/packages/renderer/src/locales/nb.ts
@@ -74,7 +74,7 @@ export const nbMessages: GoalProgressMessages = {
   preparingBaseline: "Oppretter utgangspunkt for fremdrift…",
   preparingObjectives: "Forbereder godkjenningspunkter…",
   preparingCopy: "Gjeldende modell kontrollerer Goal og godkjenningslisten.",
-  unavailableTitle: "Goal-fremdrift er utilgjengelig",
+  unavailableTitle: "Fremdriften er ikke oppdatert",
   unavailableCopy: "Goal kan fortsette. Fremdriften vises igjen når tilkoblingen er gjenopprettet.",
   retryProgress: "Prøv fremdrift på nytt",
   retry: "Prøv igjen",

--- a/runtime/source/packages/renderer/src/locales/nl.ts
+++ b/runtime/source/packages/renderer/src/locales/nl.ts
@@ -74,7 +74,7 @@ export const nlMessages: GoalProgressMessages = {
   preparingBaseline: "Uitgangspunt voor voortgang bepalen…",
   preparingObjectives: "Acceptatiepunten voorbereiden…",
   preparingCopy: "Het huidige model controleert de Goal en acceptatielijst.",
-  unavailableTitle: "Goal-voortgang is niet beschikbaar",
+  unavailableTitle: "Voortgang niet bijgewerkt",
   unavailableCopy:
     "De Goal kan doorgaan. De voortgang verschijnt weer zodra de verbinding is hersteld.",
   retryProgress: "Voortgang opnieuw proberen",

--- a/runtime/source/packages/renderer/src/locales/pa.ts
+++ b/runtime/source/packages/renderer/src/locales/pa.ts
@@ -74,7 +74,7 @@ export const paMessages: GoalProgressMessages = {
   preparingBaseline: "ਪ੍ਰਗਤੀ ਦਾ ਆਧਾਰ ਤਿਆਰ ਹੋ ਰਿਹਾ ਹੈ…",
   preparingObjectives: "ਸਵੀਕ੍ਰਿਤੀ ਬਿੰਦੂ ਤਿਆਰ ਹੋ ਰਹੇ ਹਨ…",
   preparingCopy: "ਮੌਜੂਦਾ ਮਾਡਲ Goal ਅਤੇ ਸਵੀਕ੍ਰਿਤੀ ਸੂਚੀ ਦੀ ਜਾਂਚ ਕਰ ਰਿਹਾ ਹੈ।",
-  unavailableTitle: "Goal ਪ੍ਰਗਤੀ ਉਪਲਬਧ ਨਹੀਂ",
+  unavailableTitle: "ਤਰੱਕੀ ਅੱਪਡੇਟ ਨਹੀਂ ਹੋਈ",
   unavailableCopy: "Goal ਜਾਰੀ ਰਹਿ ਸਕਦਾ ਹੈ। ਕਨੈਕਸ਼ਨ ਠੀਕ ਹੋਣ 'ਤੇ ਪ੍ਰਗਤੀ ਮੁੜ ਦਿਖੇਗੀ।",
   retryProgress: "ਪ੍ਰਗਤੀ ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰੋ",
   retry: "ਮੁੜ ਕੋਸ਼ਿਸ਼ ਕਰੋ",

--- a/runtime/source/packages/renderer/src/locales/pl.ts
+++ b/runtime/source/packages/renderer/src/locales/pl.ts
@@ -74,7 +74,7 @@ export const plMessages: GoalProgressMessages = {
   preparingBaseline: "Ustalanie punktu odniesienia postępu…",
   preparingObjectives: "Przygotowywanie punktów odbioru…",
   preparingCopy: "Bieżący model sprawdza Goal i listę odbioru.",
-  unavailableTitle: "Postęp Goal jest niedostępny",
+  unavailableTitle: "Postęp nie został zaktualizowany",
   unavailableCopy: "Goal może działać dalej. Postęp wróci po odzyskaniu połączenia.",
   retryProgress: "Ponów wczytywanie postępu",
   retry: "Ponów",

--- a/runtime/source/packages/renderer/src/locales/pt-br.ts
+++ b/runtime/source/packages/renderer/src/locales/pt-br.ts
@@ -74,7 +74,7 @@ export const ptBRMessages: GoalProgressMessages = {
   preparingBaseline: "Criando a base do progresso…",
   preparingObjectives: "Preparando pontos de aceitação…",
   preparingCopy: "O modelo atual está verificando o Goal e a lista de aceitação.",
-  unavailableTitle: "O progresso do Goal está indisponível",
+  unavailableTitle: "Progresso não atualizado",
   unavailableCopy: "O Goal pode continuar. O progresso voltará quando a conexão for restabelecida.",
   retryProgress: "Tentar carregar o progresso novamente",
   retry: "Tentar novamente",

--- a/runtime/source/packages/renderer/src/locales/pt-pt.ts
+++ b/runtime/source/packages/renderer/src/locales/pt-pt.ts
@@ -74,7 +74,7 @@ export const ptPTMessages: GoalProgressMessages = {
   preparingBaseline: "A criar a referência de progresso…",
   preparingObjectives: "A preparar pontos de aceitação…",
   preparingCopy: "O modelo atual está a verificar o Goal e a lista de aceitação.",
-  unavailableTitle: "O progresso do Goal está indisponível",
+  unavailableTitle: "Progresso não atualizado",
   unavailableCopy: "O Goal pode continuar. O progresso voltará quando a ligação for restabelecida.",
   retryProgress: "Tentar carregar o progresso novamente",
   retry: "Tentar novamente",

--- a/runtime/source/packages/renderer/src/locales/ro.ts
+++ b/runtime/source/packages/renderer/src/locales/ro.ts
@@ -74,7 +74,7 @@ export const roMessages: GoalProgressMessages = {
   preparingBaseline: "Se stabilește baza progresului…",
   preparingObjectives: "Se pregătesc punctele de acceptare…",
   preparingCopy: "Modelul curent verifică Goal-ul și lista de acceptare.",
-  unavailableTitle: "Progresul Goal nu este disponibil",
+  unavailableTitle: "Progres neactualizat",
   unavailableCopy: "Goal-ul poate continua. Progresul va reveni când se restabilește conexiunea.",
   retryProgress: "Reîncearcă încărcarea progresului",
   retry: "Reîncearcă",

--- a/runtime/source/packages/renderer/src/locales/ru.ts
+++ b/runtime/source/packages/renderer/src/locales/ru.ts
@@ -74,7 +74,7 @@ export const ruMessages: GoalProgressMessages = {
   preparingBaseline: "Подготовка исходного прогресса…",
   preparingObjectives: "Подготовка критериев приёмки…",
   preparingCopy: "Текущая модель проверяет Goal и список приёмки.",
-  unavailableTitle: "Прогресс Goal недоступен",
+  unavailableTitle: "Прогресс не обновлён",
   unavailableCopy:
     "Goal может продолжать работу. Прогресс вернётся после восстановления подключения.",
   retryProgress: "Повторить загрузку прогресса",

--- a/runtime/source/packages/renderer/src/locales/sk.ts
+++ b/runtime/source/packages/renderer/src/locales/sk.ts
@@ -74,7 +74,7 @@ export const skMessages: GoalProgressMessages = {
   preparingBaseline: "Vytvára sa základ priebehu…",
   preparingObjectives: "Pripravujú sa body prijatia…",
   preparingCopy: "Aktuálny model kontroluje Goal a kontrolný zoznam prijatia.",
-  unavailableTitle: "Priebeh Goal nie je dostupný",
+  unavailableTitle: "Priebeh nie je aktualizovaný",
   unavailableCopy: "Goal môže pokračovať. Priebeh sa vráti po obnovení pripojenia.",
   retryProgress: "Znova načítať priebeh",
   retry: "Skúsiť znova",

--- a/runtime/source/packages/renderer/src/locales/sl.ts
+++ b/runtime/source/packages/renderer/src/locales/sl.ts
@@ -74,7 +74,7 @@ export const slMessages: GoalProgressMessages = {
   preparingBaseline: "Vzpostavljanje osnove napredka…",
   preparingObjectives: "Priprava točk sprejema…",
   preparingCopy: "Trenutni model preverja Goal in kontrolni seznam sprejema.",
-  unavailableTitle: "Napredek Goal ni na voljo",
+  unavailableTitle: "Napredek ni posodobljen",
   unavailableCopy: "Goal se lahko nadaljuje. Napredek se vrne, ko se povezava obnovi.",
   retryProgress: "Znova naloži napredek",
   retry: "Poskusi znova",

--- a/runtime/source/packages/renderer/src/locales/so.ts
+++ b/runtime/source/packages/renderer/src/locales/so.ts
@@ -74,7 +74,7 @@ export const soMessages: GoalProgressMessages = {
   preparingBaseline: "Saldhigga horumarka ayaa la diyaarinayaa…",
   preparingObjectives: "Qodobbada aqbalaadda ayaa la diyaarinayaa…",
   preparingCopy: "Moodalka hadda wuxuu hubinayaa Goal iyo liiska aqbalaadda.",
-  unavailableTitle: "Horumarka Goal lama heli karo",
+  unavailableTitle: "Horumarka lama cusboonaysiin",
   unavailableCopy: "Goal wuu sii socon karaa. Horumarku wuu soo noqonayaa marka xiriirku hagaago.",
   retryProgress: "Mar kale soo rar horumarka",
   retry: "Mar kale isku day",

--- a/runtime/source/packages/renderer/src/locales/sq.ts
+++ b/runtime/source/packages/renderer/src/locales/sq.ts
@@ -74,7 +74,7 @@ export const sqMessages: GoalProgressMessages = {
   preparingBaseline: "Duke krijuar bazën e përparimit…",
   preparingObjectives: "Duke përgatitur pikat e pranimit…",
   preparingCopy: "Modeli aktual po kontrollon Goal-in dhe listën e pranimit.",
-  unavailableTitle: "Përparimi i Goal-it nuk është i disponueshëm",
+  unavailableTitle: "Përparimi nuk është përditësuar",
   unavailableCopy: "Goal-i mund të vazhdojë. Përparimi do të rikthehet kur të rregullohet lidhja.",
   retryProgress: "Riprovo ngarkimin e përparimit",
   retry: "Riprovo",

--- a/runtime/source/packages/renderer/src/locales/sr.ts
+++ b/runtime/source/packages/renderer/src/locales/sr.ts
@@ -74,7 +74,7 @@ export const srMessages: GoalProgressMessages = {
   preparingBaseline: "Постављање основе напретка…",
   preparingObjectives: "Припрема тачака прихватања…",
   preparingCopy: "Тренутни модел проверава Goal и листу прихватања.",
-  unavailableTitle: "Напредак Goal није доступан",
+  unavailableTitle: "Напредак није ажуриран",
   unavailableCopy: "Goal може да настави. Напредак ће се вратити када се веза обнови.",
   retryProgress: "Поново учитај напредак",
   retry: "Покушај поново",

--- a/runtime/source/packages/renderer/src/locales/sv.ts
+++ b/runtime/source/packages/renderer/src/locales/sv.ts
@@ -74,7 +74,7 @@ export const svMessages: GoalProgressMessages = {
   preparingBaseline: "Skapar utgångspunkt för förloppet…",
   preparingObjectives: "Förbereder godkännandepunkter…",
   preparingCopy: "Den aktuella modellen kontrollerar Goal och godkännandelistan.",
-  unavailableTitle: "Goal-förloppet är inte tillgängligt",
+  unavailableTitle: "Förloppet har inte uppdaterats",
   unavailableCopy: "Goal kan fortsätta. Förloppet visas igen när anslutningen återställs.",
   retryProgress: "Försök läsa in förloppet igen",
   retry: "Försök igen",

--- a/runtime/source/packages/renderer/src/locales/sw.ts
+++ b/runtime/source/packages/renderer/src/locales/sw.ts
@@ -74,7 +74,7 @@ export const swMessages: GoalProgressMessages = {
   preparingBaseline: "Inaweka msingi wa maendeleo…",
   preparingObjectives: "Inaandaa vipengee vya kukubali…",
   preparingCopy: "Muundo wa sasa unaangalia Goal na orodha ya kukubali.",
-  unavailableTitle: "Maendeleo ya Goal hayapatikani",
+  unavailableTitle: "Maendeleo hayajasasishwa",
   unavailableCopy: "Goal inaweza kuendelea. Maendeleo yatarudi muunganisho ukirejea.",
   retryProgress: "Jaribu kupakia maendeleo tena",
   retry: "Jaribu tena",

--- a/runtime/source/packages/renderer/src/locales/ta.ts
+++ b/runtime/source/packages/renderer/src/locales/ta.ts
@@ -74,7 +74,7 @@ export const taMessages: GoalProgressMessages = {
   preparingBaseline: "முன்னேற்ற அடிப்படையை அமைக்கிறது…",
   preparingObjectives: "ஏற்புப் புள்ளிகளைத் தயாரிக்கிறது…",
   preparingCopy: "தற்போதைய மாதிரி Goal மற்றும் ஏற்புப் பட்டியலைச் சரிபார்க்கிறது.",
-  unavailableTitle: "Goal முன்னேற்றம் கிடைக்கவில்லை",
+  unavailableTitle: "முன்னேற்றம் புதுப்பிக்கப்படவில்லை",
   unavailableCopy: "Goal தொடர்ந்து இயங்கலாம். இணைப்பு மீண்டதும் முன்னேற்றம் திரும்பும்.",
   retryProgress: "முன்னேற்றத்தை மீண்டும் ஏற்று",
   retry: "மீண்டும் முயல்க",

--- a/runtime/source/packages/renderer/src/locales/te.ts
+++ b/runtime/source/packages/renderer/src/locales/te.ts
@@ -74,7 +74,7 @@ export const teMessages: GoalProgressMessages = {
   preparingBaseline: "పురోగతి ఆధారాన్ని సిద్ధం చేస్తోంది…",
   preparingObjectives: "అంగీకార అంశాలను సిద్ధం చేస్తోంది…",
   preparingCopy: "ప్రస్తుత మోడల్ Goal మరియు అంగీకార జాబితాను తనిఖీ చేస్తోంది.",
-  unavailableTitle: "Goal పురోగతి అందుబాటులో లేదు",
+  unavailableTitle: "పురోగతి నవీకరించబడలేదు",
   unavailableCopy: "Goal కొనసాగవచ్చు. కనెక్షన్ తిరిగి వచ్చినప్పుడు పురోగతి కనిపిస్తుంది.",
   retryProgress: "పురోగతిని మళ్లీ లోడ్ చేయండి",
   retry: "మళ్లీ ప్రయత్నించండి",

--- a/runtime/source/packages/renderer/src/locales/th.ts
+++ b/runtime/source/packages/renderer/src/locales/th.ts
@@ -74,7 +74,7 @@ export const thMessages: GoalProgressMessages = {
   preparingBaseline: "กำลังสร้างค่าตั้งต้นของความคืบหน้า…",
   preparingObjectives: "กำลังเตรียมจุดตรวจรับ…",
   preparingCopy: "โมเดลปัจจุบันกำลังตรวจสอบ Goal และรายการตรวจรับ",
-  unavailableTitle: "ความคืบหน้าของ Goal ไม่พร้อมใช้งาน",
+  unavailableTitle: "ยังไม่อัปเดตความคืบหน้า",
   unavailableCopy: "Goal ทำงานต่อได้ ความคืบหน้าจะกลับมาเมื่อเชื่อมต่อได้อีกครั้ง",
   retryProgress: "ลองโหลดความคืบหน้าอีกครั้ง",
   retry: "ลองอีกครั้ง",

--- a/runtime/source/packages/renderer/src/locales/tl.ts
+++ b/runtime/source/packages/renderer/src/locales/tl.ts
@@ -74,7 +74,7 @@ export const tlMessages: GoalProgressMessages = {
   preparingBaseline: "Inihahanda ang batayan ng progreso…",
   preparingObjectives: "Inihahanda ang mga punto ng pagtanggap…",
   preparingCopy: "Sinusuri ng kasalukuyang modelo ang Goal at listahan ng pagtanggap.",
-  unavailableTitle: "Hindi available ang progreso ng Goal",
+  unavailableTitle: "Hindi pa na-update ang progreso",
   unavailableCopy:
     "Maaaring magpatuloy ang Goal. Babalik ang progreso kapag bumalik ang koneksyon.",
   retryProgress: "I-load muli ang progreso",

--- a/runtime/source/packages/renderer/src/locales/tr.ts
+++ b/runtime/source/packages/renderer/src/locales/tr.ts
@@ -74,7 +74,7 @@ export const trMessages: GoalProgressMessages = {
   preparingBaseline: "İlerleme temeli hazırlanıyor…",
   preparingObjectives: "Kabul noktaları hazırlanıyor…",
   preparingCopy: "Geçerli model Goal'u ve kabul listesini denetliyor.",
-  unavailableTitle: "Goal ilerlemesi kullanılamıyor",
+  unavailableTitle: "İlerleme güncellenmedi",
   unavailableCopy: "Goal çalışmaya devam edebilir. Bağlantı düzeldiğinde ilerleme geri gelir.",
   retryProgress: "İlerlemeyi yeniden yükle",
   retry: "Yeniden dene",

--- a/runtime/source/packages/renderer/src/locales/uk.ts
+++ b/runtime/source/packages/renderer/src/locales/uk.ts
@@ -74,7 +74,7 @@ export const ukMessages: GoalProgressMessages = {
   preparingBaseline: "Створення основи прогресу…",
   preparingObjectives: "Підготовка критеріїв приймання…",
   preparingCopy: "Поточна модель перевіряє Goal і список приймання.",
-  unavailableTitle: "Прогрес Goal недоступний",
+  unavailableTitle: "Прогрес не оновлено",
   unavailableCopy: "Goal може працювати далі. Прогрес повернеться після відновлення з'єднання.",
   retryProgress: "Повторити завантаження прогресу",
   retry: "Повторити",

--- a/runtime/source/packages/renderer/src/locales/ur.ts
+++ b/runtime/source/packages/renderer/src/locales/ur.ts
@@ -74,7 +74,7 @@ export const urMessages: GoalProgressMessages = {
   preparingBaseline: "پیش رفت کی بنیاد تیار ہو رہی ہے…",
   preparingObjectives: "قبولیت کے نکات تیار ہو رہے ہیں…",
   preparingCopy: "موجودہ ماڈل Goal اور قبولیت کی فہرست جانچ رہا ہے۔",
-  unavailableTitle: "Goal کی پیش رفت دستیاب نہیں",
+  unavailableTitle: "پیش رفت اپ ڈیٹ نہیں ہوئی",
   unavailableCopy: "Goal جاری رہ سکتا ہے۔ رابطہ بحال ہونے پر پیش رفت واپس آ جائے گی۔",
   retryProgress: "پیش رفت دوبارہ لوڈ کریں",
   retry: "دوبارہ کوشش کریں",

--- a/runtime/source/packages/renderer/src/locales/vi.ts
+++ b/runtime/source/packages/renderer/src/locales/vi.ts
@@ -74,7 +74,7 @@ export const viMessages: GoalProgressMessages = {
   preparingBaseline: "Đang thiết lập mốc tiến độ…",
   preparingObjectives: "Đang chuẩn bị các điểm nghiệm thu…",
   preparingCopy: "Mô hình hiện tại đang kiểm tra Goal và danh sách nghiệm thu.",
-  unavailableTitle: "Tiến độ Goal không khả dụng",
+  unavailableTitle: "Tiến độ chưa được cập nhật",
   unavailableCopy: "Goal vẫn có thể tiếp tục. Tiến độ sẽ trở lại khi kết nối được khôi phục.",
   retryProgress: "Tải lại tiến độ",
   retry: "Thử lại",

--- a/runtime/source/packages/renderer/src/locales/zh-cn.ts
+++ b/runtime/source/packages/renderer/src/locales/zh-cn.ts
@@ -74,7 +74,7 @@ export const zhCNMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立进度基线…",
   preparingObjectives: "正在准备专属验收点…",
   preparingCopy: "当前模型正在检查目标与验收清单。",
-  unavailableTitle: "目标进度暂不可用",
+  unavailableTitle: "进度暂未更新",
   unavailableCopy: "Goal 可以继续工作。连接恢复后，进度会重新显示。",
   retryProgress: "重试进度",
   retry: "重试",

--- a/runtime/source/packages/renderer/src/locales/zh-hk.ts
+++ b/runtime/source/packages/renderer/src/locales/zh-hk.ts
@@ -74,7 +74,7 @@ export const zhHKMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立進度基準…",
   preparingObjectives: "正在準備驗收項目…",
   preparingCopy: "目前的模型正在檢查 Goal 及驗收清單。",
-  unavailableTitle: "目標進度暫時無法使用",
+  unavailableTitle: "進度暫未更新",
   unavailableCopy: "Goal 可以繼續運作。連線恢復後，進度會再次顯示。",
   retryProgress: "重新載入進度",
   retry: "重試",

--- a/runtime/source/packages/renderer/src/locales/zh-tw.ts
+++ b/runtime/source/packages/renderer/src/locales/zh-tw.ts
@@ -74,7 +74,7 @@ export const zhTWMessages: GoalProgressMessages = {
   preparingBaseline: "正在建立進度基準…",
   preparingObjectives: "正在準備驗收項目…",
   preparingCopy: "目前的模型正在檢查 Goal 與驗收清單。",
-  unavailableTitle: "目標進度目前無法使用",
+  unavailableTitle: "進度暫未更新",
   unavailableCopy: "Goal 可以繼續執行。連線恢復後，進度會再次顯示。",
   retryProgress: "重試載入進度",
   retry: "重試",

--- a/runtime/source/packages/renderer/src/styles/states.ts
+++ b/runtime/source/packages/renderer/src/styles/states.ts
@@ -10,10 +10,6 @@ export const stateStyles = css`
       text-align: center;
     }
 
-    .phase-error .state {
-      min-height: calc(var(--gp-font-size) * 10.857143);
-    }
-
     .state-symbol {
       position: relative;
       display: grid;
@@ -46,11 +42,6 @@ export const stateStyles = css`
       content: none;
     }
 
-    .state-symbol.error {
-      border-color: color-mix(in srgb, var(--gp-blocked) 56%, transparent);
-      color: var(--gp-blocked);
-    }
-
     .state-title {
       color: var(--gp-text);
       font-size: max(10px, calc(var(--gp-font-size) - 2px));
@@ -66,20 +57,67 @@ export const stateStyles = css`
       line-height: 1.5;
     }
 
-    .error-code {
-      display: inline-block;
-      margin-top: calc(var(--gp-font-size) * 0.571429);
-      color: var(--gp-blocked);
-      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      font-size: max(9px, calc(var(--gp-font-size) - 5px));
-      overflow-wrap: anywhere;
+    .phase-error .state {
+      display: flex;
+      min-height: 36px;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 4px;
+      padding: 4px 8px 4px 12px;
+      color: var(--gp-muted);
+      font-size: var(--gp-font-size-sm);
+      line-height: 1.35;
+      text-align: start;
+    }
+
+    .error-summary {
+      overflow: hidden;
+      min-width: 0;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .state-actions {
       display: flex;
-      justify-content: center;
-      gap: calc(var(--gp-font-size) * 0.285714);
-      margin-top: calc(var(--gp-font-size) * 0.714286);
+      flex: none;
+      align-items: center;
+      gap: 2px;
+      margin-inline-start: auto;
+    }
+
+    .retry-button {
+      min-height: 24px;
+      border: 0;
+      border-radius: var(--gp-control-radius);
+      padding: 2px 6px;
+      background: transparent;
+      color: var(--gp-accent);
+      cursor: pointer;
+      font: inherit;
+    }
+
+    .retry-button:hover,
+    .retry-button:focus-visible {
+      background: var(--gp-control-hover);
+    }
+
+    .retry-button:focus-visible {
+      outline: 2px solid var(--gp-focus);
+      outline-offset: 1px;
+    }
+
+    .panel.phase-error.placement-floating .state {
+      position: absolute;
+      z-index: 1;
+      bottom: var(--gp-floating-stack-lift, 0px);
+      left: var(--gp-floating-chip-center, 50%);
+      width: min(280px, calc(100% - 20px));
+      border: 1px solid var(--gp-line);
+      border-radius: 15px;
+      background: var(--gp-panel-glass);
+      box-shadow: none;
+      pointer-events: auto;
+      transform: translateX(-50%);
     }
 
     .sr-only {

--- a/runtime/source/platform/macos/src/plugin-release.ts
+++ b/runtime/source/platform/macos/src/plugin-release.ts
@@ -38,6 +38,20 @@ function record(value: unknown, code: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+export function createReleaseMarketplaceManifest(sourceMarketplace: unknown): string {
+  const code = "GOAL_PROGRESS_RELEASE_MARKETPLACE_INVALID";
+  const marketplace = structuredClone(record(sourceMarketplace, code));
+  if (!Array.isArray(marketplace.plugins)) throw new Error(code);
+  const plugin = marketplace.plugins.find(
+    (entry: unknown) => record(entry, code).name === "codex-goal-progress",
+  );
+  if (!plugin) throw new Error(code);
+  const source = record(record(plugin, code).source, code);
+  if (source.source !== "local") throw new Error(code);
+  source.path = "./plugins/codex-goal-progress";
+  return `${JSON.stringify(marketplace, null, 2)}\n`;
+}
+
 export function createReleasePluginManifest(sourceManifest: unknown): string {
   const manifest = structuredClone(record(sourceManifest, "GOAL_PROGRESS_PLUGIN_MANIFEST_INVALID"));
   delete manifest.scripts;

--- a/scripts/build_macos_release.ts
+++ b/scripts/build_macos_release.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
 import { writePluginTreeManifest } from "../platform/macos/src/plugin-integrity.js";
 import {
+  createReleaseMarketplaceManifest,
   createReleasePluginManifest,
   createReleasePluginRuntimeFiles,
   writeReleasePluginRuntimeFiles,
@@ -175,9 +176,11 @@ async function main(): Promise<void> {
   const marketplaceRoot = resolve(workRoot, "plugin-marketplace");
   const releasePluginRoot = resolve(marketplaceRoot, "plugins/codex-goal-progress");
   await mkdir(resolve(marketplaceRoot, ".agents/plugins"), { recursive: true });
-  await copyFile(
-    resolve(root, ".agents/plugins/marketplace.json"),
+  await writeFile(
     resolve(marketplaceRoot, ".agents/plugins/marketplace.json"),
+    createReleaseMarketplaceManifest(
+      JSON.parse(await readFile(resolve(root, ".agents/plugins/marketplace.json"), "utf8")),
+    ),
   );
   await cp(resolve(root, "plugins/codex-goal-progress"), releasePluginRoot, {
     recursive: true,

--- a/scripts/build_renderer_bundle.mjs
+++ b/scripts/build_renderer_bundle.mjs
@@ -10,7 +10,7 @@ const bundlePath = resolve(outputDirectory, "goal-progress.js");
 const manifestPath = resolve(outputDirectory, "goal-progress.manifest.json");
 const packageJson = JSON.parse(await readFile(resolve(root, "package.json"), "utf8"));
 const pageHostVersionManifest = JSON.parse(
-  await readFile(resolve(root, "packages/codex-adapter/src/page-host-version.json"), "utf8"),
+  await readFile(resolve(root, "packages/contracts/src/page-host-version.json"), "utf8"),
 );
 const pageHostVersion = pageHostVersionManifest.pageHostVersion;
 if (!Number.isSafeInteger(pageHostVersion) || pageHostVersion < 1) {


### PR DESCRIPTION
## Summary

- Replace the large error card with a compact status line at the existing progress position. Retain the last confirmed percentage, Retry, and Close.
- Keep task blockers separate from plugin failures and preserve the native paused state, checklist, and progress.
- Refresh same-version renderer reinstalls and keep floating error controls inside narrow windows.
- Correct the prebuilt marketplace entry and the clean source-runtime build path after the shared renderer revision moved.
- Add a clean source-runtime build to public CI and update the v0.3.5 release notes.
- Update vulnerable MCP transitive dependencies: `fast-uri` 3.1.7 and `qs` 6.16.0.

## Verification

- Internal unit/integration suite: 857 passed; two optional model evaluations skipped.
- Browser regression suite: all 117 passed after correcting two asynchronous-layout observation assertions; geometry limits were preserved.
- Final fast gate, public `pnpm verify`, and a clean build from exported `runtime/source` passed.
- Production dependency audit: zero known vulnerabilities after resolving `fast-uri` 3.1.7 and `qs` 6.16.0.
- macOS arm64 package built from this public branch; checksums and ad-hoc signatures verified.
- Reinstalled the candidate and passed Doctor/Verify with all installed files matching the package and existing user state unchanged.
- Real Codex 26.901.51231 (8109): automatic recovery after the app update, retained 50% test progress, paused animations, and working compact Retry/Close in floating and inline layouts.

Native Pause/Stop behavior is unchanged. Progress continues to synchronize at its existing polling cadence.
The v0.3.5 package has been built and tested locally; this PR does not publish a GitHub release.
