### PR TITLE
build: make macOS release assembly clean-clone safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Refresh the renderer after same-version reinstalls and keep floating status controls inside narrow windows.
 - Build source and prebuilt packages from the same renderer revision and correct the nested prebuilt marketplace entry.
 - Update MCP transitive dependencies to `fast-uri` 3.1.7 and `qs` 6.16.0; the production audit reports no known vulnerabilities.
+- Rebuild the source plugin before assembling the macOS release, so `pnpm build:release:macos` works from a clean clone.
 
 ## 0.3.4 - 2026-09-02
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:code": "node scripts/build_code.mjs",
     "build:renderer": "node scripts/build_renderer_bundle.mjs",
     "build:plugin": "node scripts/build_plugin_package.mjs",
-    "build:release:macos": "pnpm build:renderer && tsx scripts/build_macos_release.ts",
+    "build:release:macos": "pnpm build:plugin && pnpm build:renderer && tsx scripts/build_macos_release.ts",
     "package:release:macos": "node scripts/package_macos_update_assets.mjs",
     "build": "pnpm build:code && pnpm build:renderer && pnpm build:plugin",
     "verify": "pnpm verify:public",


### PR DESCRIPTION
## Summary

- Build the source plugin before assembling the macOS release.
- Make `pnpm build:release:macos` work from a clean clone without relying on generated leftovers.
- Record the clean-build fix in the v0.3.5 changelog.

## Source

Exported from internal integration commit `aa8ced1ef5539e2168ff2d49d81e7a4357ad6880` after internal PR #35 was merged.

## Verification

- Public `pnpm verify` passed.
- Production dependency audit reports zero known vulnerabilities.
- Removed both `dist` and `plugins`, then ran `GOAL_PROGRESS_NODE_BINARY=<verified Node v24.19.0 arm64> pnpm build:release:macos`; it passed.
- Packaged update assets, verified SHA-256, ZIP integrity, signatures, and all release/update/renderer versions as 0.3.5.