### PR TITLE
fix: target startup listener for macOS 13

### DIFF
--- a/scripts/build_macos_release.ts
+++ b/scripts/build_macos_release.ts
@@ -145,7 +145,17 @@ async function main(): Promise<void> {
   const startupListenerSource = resolve(root, "platform/macos/startup-listener/main.swift");
   run(
     "/usr/bin/xcrun",
-    ["swiftc", "-O", "-framework", "AppKit", startupListenerSource, "-o", startupListenerPath],
+    [
+      "swiftc",
+      "-O",
+      "-target",
+      "arm64-apple-macosx13.0",
+      "-framework",
+      "AppKit",
+      startupListenerSource,
+      "-o",
+      startupListenerPath,
+    ],
     "GOAL_PROGRESS_STARTUP_LISTENER_BUILD_FAILED",
   );
   assertReleaseBinaryHygiene(await readFile(startupListenerPath), [root, outputRoot, workRoot]);


### PR DESCRIPTION
## Problem

The macOS release builder invokes `swiftc` without a deployment target. A release built with the macOS 26 SDK therefore contains a `goal-progress-startup-listener` binary with `minos 26.0`.

The v0.3.7 installer fails on macOS 15.7.8 before the listener starts. The dynamic loader reports that the binary was built for a newer macOS version and cannot load `/usr/lib/swift/libswift_DarwinFoundation2.dylib`. Doctor then reports `GOAL_PROGRESS_INSTALL_DOCTOR_FAILED`, and the installer rolls back.

## Change

Compile the arm64 startup listener with an explicit `arm64-apple-macosx13.0` target. The current Codex Desktop app declares macOS 13.0 as its minimum system version.

## Verification

- `pnpm verify:public`
- Full `pnpm build:release:macos` with Node v24.19.0
- `vtool -show-build` reports `minos 13.0` for the rebuilt listener
- `codesign --verify --strict` passes
- Every entry in the generated `SHA256SUMS` passes
- The rebuilt listener starts on macOS 15.7.8
